### PR TITLE
Update cleanup

### DIFF
--- a/samples/fleets_demo.cpp
+++ b/samples/fleets_demo.cpp
@@ -27,7 +27,7 @@ public:
 
     }
 
-    void do_fixed_update(double dt) override {
+    void fixed_update(double dt) override {
         Vec3 speed(-250, 0, 0.0);
 
         Vec3 avg;

--- a/samples/fleets_demo.cpp
+++ b/samples/fleets_demo.cpp
@@ -27,7 +27,7 @@ public:
 
     }
 
-    void do_step(double dt) override {
+    void do_fixed_update(double dt) override {
         Vec3 speed(-250, 0, 0.0);
 
         Vec3 avg;

--- a/samples/joypad_sample.cpp
+++ b/samples/joypad_sample.cpp
@@ -164,7 +164,7 @@ public:
         }
     }
 
-    void do_step(double dt) {
+    void do_fixed_update(double dt) {
         auto actor = window->stage(stage_id_)->actor(actor_id);
         actor->rotate_x_by(smlt::Degrees(rot.y * dt * 10));
         actor->rotate_y_by(smlt::Degrees(rot.x * dt * 10));

--- a/samples/joypad_sample.cpp
+++ b/samples/joypad_sample.cpp
@@ -164,7 +164,7 @@ public:
         }
     }
 
-    void do_fixed_update(double dt) {
+    void fixed_update(double dt) {
         auto actor = window->stage(stage_id_)->actor(actor_id);
         actor->rotate_x_by(smlt::Degrees(rot.y * dt * 10));
         actor->rotate_y_by(smlt::Degrees(rot.x * dt * 10));

--- a/samples/light_sample.cpp
+++ b/samples/light_sample.cpp
@@ -59,7 +59,7 @@ public:
         });
     }
 
-    void do_step(double dt) {
+    void do_fixed_update(double dt) {
         window->stage(stage_id_)->actor(actor_id_)->rotate_x_by(smlt::Degrees(dt * 20.0));
         window->stage(stage_id_)->actor(actor_id_)->rotate_y_by(smlt::Degrees(dt * 15.0));
         window->stage(stage_id_)->actor(actor_id_)->rotate_z_by(smlt::Degrees(dt * 25.0));

--- a/samples/light_sample.cpp
+++ b/samples/light_sample.cpp
@@ -59,7 +59,7 @@ public:
         });
     }
 
-    void do_fixed_update(double dt) {
+    void fixed_update(double dt) {
         window->stage(stage_id_)->actor(actor_id_)->rotate_x_by(smlt::Degrees(dt * 20.0));
         window->stage(stage_id_)->actor(actor_id_)->rotate_y_by(smlt::Degrees(dt * 15.0));
         window->stage(stage_id_)->actor(actor_id_)->rotate_z_by(smlt::Degrees(dt * 25.0));

--- a/samples/physics_demo.cpp
+++ b/samples/physics_demo.cpp
@@ -74,7 +74,7 @@ public:
         });
     }
 
-    void do_fixed_update(double step) override {
+    void fixed_update(double step) override {
         simulation_->fixed_update(step);
     }
 

--- a/samples/physics_demo.cpp
+++ b/samples/physics_demo.cpp
@@ -74,8 +74,8 @@ public:
         });
     }
 
-    void do_step(double dt) override {
-        simulation_->step(dt);
+    void do_fixed_update(double step) override {
+        simulation_->fixed_update(step);
     }
 
 private:

--- a/samples/rtt_sample.cpp
+++ b/samples/rtt_sample.cpp
@@ -31,7 +31,7 @@ public:
         ).with_clear();
     }
 
-    void do_fixed_update(double dt) {
+    void fixed_update(double dt) {
         window->stage(cube_stage_)->actor(cube_)->rotate_y_by(Degrees(dt * 360));
         window->stage(rect_stage_)->actor(rect_)->rotate_y_by(Degrees(dt * 180));
     }

--- a/samples/rtt_sample.cpp
+++ b/samples/rtt_sample.cpp
@@ -31,7 +31,7 @@ public:
         ).with_clear();
     }
 
-    void do_step(double dt) {
+    void do_fixed_update(double dt) {
         window->stage(cube_stage_)->actor(cube_)->rotate_y_by(Degrees(dt * 360));
         window->stage(rect_stage_)->actor(rect_)->rotate_y_by(Degrees(dt * 180));
     }

--- a/samples/sample.cpp
+++ b/samples/sample.cpp
@@ -44,7 +44,7 @@ public:
         tank_actor->move_to(40, 0, -110);
     }
 
-    void do_step(double dt) {
+    void do_fixed_update(double dt) {
 
     }
 

--- a/samples/sample.cpp
+++ b/samples/sample.cpp
@@ -44,10 +44,6 @@ public:
         tank_actor->move_to(40, 0, -110);
     }
 
-    void do_fixed_update(double dt) {
-
-    }
-
 private:
     CameraID camera_id_;
     StageID stage_id_;

--- a/samples/terrain_sample.cpp
+++ b/samples/terrain_sample.cpp
@@ -95,7 +95,7 @@ public:
         window->enable_pipeline(pipeline_id_);
     }
 
-    void do_step(double dt) override {
+    void do_fixed_update(double dt) override {
         auto stage = window->stage(stage_id_);
         stage->actor(terrain_actor_id_)->rotate_global_y_by(smlt::Degrees(dt * 5.0));
     }

--- a/samples/terrain_sample.cpp
+++ b/samples/terrain_sample.cpp
@@ -95,7 +95,7 @@ public:
         window->enable_pipeline(pipeline_id_);
     }
 
-    void do_fixed_update(double dt) override {
+    void fixed_update(double dt) override {
         auto stage = window->stage(stage_id_);
         stage->actor(terrain_actor_id_)->rotate_global_y_by(smlt::Degrees(dt * 5.0));
     }

--- a/simulant.files
+++ b/simulant.files
@@ -1539,3 +1539,4 @@ simulant/keycodes.h
 simulant/utils/rect_pack.h
 simulant/utils/rect_pack.cpp
 tests/test_aabb.h
+simulant/controllers/controller.cpp

--- a/simulant/application.cpp
+++ b/simulant/application.cpp
@@ -52,15 +52,14 @@ void Application::construct_window(const AppConfig& config) {
     }
 
     if(!window_->_init()) {
-        throw InstanceInitializationError("Unabel to create window");
+        throw InstanceInitializationError("Unable to create window");
     }
 
     routes_.reset(new ScreenManager(*window_));
 
     window_->set_title(config.title.encode());
 
-    window_->signal_step().connect(std::bind(&Application::do_step, this, std::placeholders::_1));
-    window_->signal_post_step().connect(std::bind(&Application::do_post_step, this, std::placeholders::_1));
+    window_->signal_fixed_update().connect(std::bind(&Application::do_fixed_update, this, std::placeholders::_1));
     window_->signal_shutdown().connect(std::bind(&Application::do_cleanup, this));
 
     window_->keyboard->key_pressed_connect(std::bind(&Application::on_key_press, this, std::placeholders::_1));

--- a/simulant/application.h
+++ b/simulant/application.h
@@ -106,8 +106,7 @@ private:
     bool initialized_ = false;
 
     virtual bool do_init() = 0;
-    virtual void do_step(double dt) {}
-    virtual void do_post_step(double dt) {}
+    virtual void do_fixed_update(double dt) {}
     virtual void do_cleanup() {}
 
     virtual bool while_key_pressed(SDL_Keysym key, double) { return false; }

--- a/simulant/controllers/controller.cpp
+++ b/simulant/controllers/controller.cpp
@@ -1,0 +1,37 @@
+#include "controller.h"
+
+namespace smlt {
+
+void Controller::enable() {
+    is_enabled_ = true;
+}
+
+void Controller::disable() {
+    is_enabled_ = false;
+}
+
+void Controller::update(double dt) {
+    if(!is_enabled_) {
+        return;
+    }
+
+    do_update(dt);
+}
+
+void Controller::late_update(double dt) {
+    if(!is_enabled_) {
+        return;
+    }
+
+    do_late_update(dt);
+}
+
+void Controller::fixed_update(double step) {
+    if(!is_enabled_) {
+        return;
+    }
+
+    do_fixed_update(step);
+}
+
+}

--- a/simulant/controllers/controller.cpp
+++ b/simulant/controllers/controller.cpp
@@ -10,28 +10,28 @@ void Controller::disable() {
     is_enabled_ = false;
 }
 
-void Controller::update(double dt) {
+void Controller::_update_thunk(double dt) {
     if(!is_enabled_) {
         return;
     }
 
-    do_update(dt);
+    Updateable::_update_thunk(dt);
 }
 
-void Controller::late_update(double dt) {
+void Controller::_late_update_thunk(double dt) {
     if(!is_enabled_) {
         return;
     }
 
-    do_late_update(dt);
+    Updateable::_late_update_thunk(dt);
 }
 
-void Controller::fixed_update(double step) {
+void Controller::_fixed_update_thunk(double step) {
     if(!is_enabled_) {
         return;
     }
 
-    do_fixed_update(step);
+    Updateable::_fixed_update_thunk(step);
 }
 
 }

--- a/simulant/controllers/controller.h
+++ b/simulant/controllers/controller.h
@@ -46,39 +46,24 @@ public:
 
     virtual ~Controller() {}
 
-    void pre_update(double dt) {
-        do_pre_update(dt);
-    }
 
     void update(double dt) {
         do_update(dt);
     }
 
-    void post_update(double dt) {
-        do_post_update(dt);
-    }
-
-    void pre_fixed_update(double step) {
-        do_pre_fixed_update(step);
+    void late_update(double dt) {
+        do_late_update(dt);
     }
 
     void fixed_update(double step) {
         do_fixed_update(step);
     }
 
-    void post_fixed_update(double step) {
-        do_post_fixed_update(step);
-    }
-
     Property<Controller, std::string> name = { this, &Controller::name_ };
 private:
-    virtual void do_pre_update(double dt) {}
     virtual void do_update(double dt) {}
-    virtual void do_post_update(double dt) {}
-
-    virtual void do_pre_fixed_update(double step) {}
+    virtual void do_late_update(double dt) {}
     virtual void do_fixed_update(double step) {}
-    virtual void do_post_fixed_update(double step) {}
 
     std::string name_;
 };
@@ -136,21 +121,9 @@ public:
         return ret;
     }
 
-    void pre_fixed_update_controllers(double step) {
-        for(auto& controller: controllers_) {
-            controller->pre_fixed_update(step);
-        }
-    }
-
     void fixed_update_controllers(double step) {
         for(auto& controller: controllers_) {
             controller->fixed_update(step);
-        }
-    }
-
-    void post_fixed_update_controllers(double step) {
-        for(auto& controller: controllers_) {
-            controller->post_fixed_update(step);
         }
     }
 
@@ -160,15 +133,9 @@ public:
         }
     }
 
-    void pre_update_controllers(double dt) {
+    void late_update_controllers(double dt) {
         for(auto& controller: controllers_) {
-            controller->pre_update(dt);
-        }
-    }
-
-    void post_update_controllers(double dt) {
-        for(auto& controller: controllers_) {
-            controller->post_update(dt);
+            controller->late_update(dt);
         }
     }
 

--- a/simulant/controllers/controller.h
+++ b/simulant/controllers/controller.h
@@ -31,6 +31,7 @@
 
 #include "../generic/property.h"
 #include "../generic/managed.h"
+#include "../interfaces/updateable.h"
 
 namespace smlt {
 
@@ -39,7 +40,8 @@ class Controller;
 
 typedef std::shared_ptr<Controller> ControllerPtr;
 
-class Controller {
+class Controller:
+    public Updateable {
 public:
     Controller(const std::string& name):
         name_(name) {}
@@ -49,17 +51,13 @@ public:
     void enable();
     void disable();
 
-    void update(double dt);
-    void late_update(double dt);
-    void fixed_update(double step);
-
     Property<Controller, std::string> name = { this, &Controller::name_ };
 
-private:
-    virtual void do_update(double dt) {}
-    virtual void do_late_update(double dt) {}
-    virtual void do_fixed_update(double step) {}
+    void _update_thunk(double dt) override;
+    void _late_update_thunk(double dt) override;
+    void _fixed_update_thunk(double step) override;
 
+private:
     std::string name_;
     bool is_enabled_ = true;
 };
@@ -119,19 +117,19 @@ public:
 
     void fixed_update_controllers(double step) {
         for(auto& controller: controllers_) {
-            controller->fixed_update(step);
+            controller->_fixed_update_thunk(step);
         }
     }
 
     void update_controllers(double dt) {
         for(auto& controller: controllers_) {
-            controller->update(dt);
+            controller->_update_thunk(dt);
         }
     }
 
     void late_update_controllers(double dt) {
         for(auto& controller: controllers_) {
-            controller->late_update(dt);
+            controller->_late_update_thunk(dt);
         }
     }
 

--- a/simulant/controllers/controller.h
+++ b/simulant/controllers/controller.h
@@ -46,26 +46,22 @@ public:
 
     virtual ~Controller() {}
 
+    void enable();
+    void disable();
 
-    void update(double dt) {
-        do_update(dt);
-    }
-
-    void late_update(double dt) {
-        do_late_update(dt);
-    }
-
-    void fixed_update(double step) {
-        do_fixed_update(step);
-    }
+    void update(double dt);
+    void late_update(double dt);
+    void fixed_update(double step);
 
     Property<Controller, std::string> name = { this, &Controller::name_ };
+
 private:
     virtual void do_update(double dt) {}
     virtual void do_late_update(double dt) {}
     virtual void do_fixed_update(double step) {}
 
     std::string name_;
+    bool is_enabled_ = true;
 };
 
 class MaterialController : public Controller {

--- a/simulant/controllers/fly.h
+++ b/simulant/controllers/fly.h
@@ -84,7 +84,7 @@ public:
     }
 
 private:
-    void do_post_update(double dt) override {
+    void do_late_update(double dt) override {
         if(moving_forward_) {
             object_->move_forward_by(600.0 * dt);
         }

--- a/simulant/controllers/fly.h
+++ b/simulant/controllers/fly.h
@@ -84,7 +84,7 @@ public:
     }
 
 private:
-    void do_late_update(double dt) override {
+    void late_update(double dt) override {
         if(moving_forward_) {
             object_->move_forward_by(600.0 * dt);
         }

--- a/simulant/controllers/material/flowing.cpp
+++ b/simulant/controllers/material/flowing.cpp
@@ -24,7 +24,7 @@ namespace smlt {
 namespace controllers {
 namespace material {
 
-void Flowing::do_update(double dt) {
+void Flowing::update(double dt) {
     float scroll = -(time_ - int(time_));
 
     auto pass = material->pass(0);

--- a/simulant/controllers/material/flowing.h
+++ b/simulant/controllers/material/flowing.h
@@ -37,7 +37,7 @@ public:
     }
 
 private:
-    void do_update(double dt) override;
+    void update(double dt) override;
     double time_ = 0.0f;
 };
 

--- a/simulant/controllers/material/warp.cpp
+++ b/simulant/controllers/material/warp.cpp
@@ -24,7 +24,7 @@ namespace smlt {
 namespace controllers {
 namespace material {
 
-void Warp::do_update(double dt) {
+void Warp::update(double dt) {
     auto pass = material->pass(0);
     auto& tex_unit = pass->texture_unit(0);
 

--- a/simulant/controllers/material/warp.h
+++ b/simulant/controllers/material/warp.h
@@ -38,7 +38,7 @@ public:
     }
 
 private:
-    void do_update(double dt) override;
+    void update(double dt) override;
     double time_ = 0.0f;
 };
 

--- a/simulant/controllers/raycast_vehicle.cpp
+++ b/simulant/controllers/raycast_vehicle.cpp
@@ -69,7 +69,7 @@ bool RaycastVehicle::init() {
     }
 }
 
-void RaycastVehicle::do_fixed_update(double dt) {
+void RaycastVehicle::fixed_update(double dt) {
     recalculate_rays();
 
     // If a roll has been detected, then fire a signal and do nothing else

--- a/simulant/controllers/raycast_vehicle.h
+++ b/simulant/controllers/raycast_vehicle.h
@@ -100,8 +100,8 @@ private:
     float turn_force_ = 0.0f;
     float drive_force_ = 0.0f;
 
-    void do_fixed_update(double dt) override;
-    void do_pre_update(double dt) {
+    void fixed_update(double dt) override;
+    void pre_update(double dt) {
         // Before we read any input or anything, clear the forces
         drive_force_ = 0.0f;
         turn_force_ = 0.0f;

--- a/simulant/controllers/rigid_body.cpp
+++ b/simulant/controllers/rigid_body.cpp
@@ -90,7 +90,7 @@ void RigidBodySimulation::cleanup() {
 
 
 
-void RigidBodySimulation::step(double dt) {
+void RigidBodySimulation::fixed_update(double dt) {
     scene_->Step();
 }
 
@@ -319,7 +319,7 @@ void Body::move_to(const Vec3& position) {
     );
 }
 
-void Body::do_post_fixed_update(double dt) {
+void Body::do_update(double dt) {
     auto xform = simulation_->body_transform(this);
     object_->move_to(xform.first);
     object_->rotate_to(xform.second);

--- a/simulant/controllers/rigid_body.cpp
+++ b/simulant/controllers/rigid_body.cpp
@@ -319,7 +319,7 @@ void Body::move_to(const Vec3& position) {
     );
 }
 
-void Body::do_update(double dt) {
+void Body::update(double dt) {
     auto xform = simulation_->body_transform(this);
     object_->move_to(xform.first);
     object_->rotate_to(xform.second);

--- a/simulant/controllers/rigid_body.h
+++ b/simulant/controllers/rigid_body.h
@@ -172,7 +172,7 @@ namespace impl {
         RigidBodySimulation::ptr simulation_;
         ColliderType collider_type_;
 
-        void do_update(double dt) override;
+        void update(double dt) override;
 
         void build_collider(ColliderType collider);
 

--- a/simulant/controllers/rigid_body.h
+++ b/simulant/controllers/rigid_body.h
@@ -109,14 +109,15 @@ struct RaycastCollider {
 class RigidBody;
 
 class RigidBodySimulation:
-    public Managed<RigidBodySimulation> {
+    public Managed<RigidBodySimulation>,
+    public std::enable_shared_from_this<RigidBodySimulation> {
 
 public:
     RigidBodySimulation();
     bool init() override;
     void cleanup() override;
 
-    void step(double dt);
+    void fixed_update(double dt);
 
     std::pair<Vec3, bool> intersect_ray(const Vec3& start, const Vec3& direction, float* distance=nullptr, Vec3 *normal=nullptr);
 
@@ -171,7 +172,7 @@ namespace impl {
         RigidBodySimulation::ptr simulation_;
         ColliderType collider_type_;
 
-        void do_post_fixed_update(double dt) override;
+        void do_update(double dt) override;
 
         void build_collider(ColliderType collider);
 

--- a/simulant/interfaces/updateable.h
+++ b/simulant/interfaces/updateable.h
@@ -12,13 +12,10 @@ namespace smlt {
 class Updateable {
 public:
     virtual ~Updateable() {}
-    virtual void update(double step) = 0;
-    virtual void pre_update(double dt) {}
-    virtual void post_update(double dt) {}
 
-    virtual void pre_fixed_update(double step) {}
+    virtual void update(double step) = 0;
+    virtual void late_update(double dt) {}
     virtual void fixed_update(double step) {}
-    virtual void post_fixed_update(double step) {}
 };
 
 }

--- a/simulant/interfaces/updateable.h
+++ b/simulant/interfaces/updateable.h
@@ -13,7 +13,24 @@ class Updateable {
 public:
     virtual ~Updateable() {}
 
-    virtual void update(double step) = 0;
+    /*
+     * Non-Virtual Interface. Simulant calls these underscore prefixed
+     * functions, and subclasses implement the more nicely named ones
+     */
+    virtual void _update_thunk(double dt) {
+        update(dt);
+    }
+
+    virtual void _late_update_thunk(double dt) {
+        late_update(dt);
+    }
+
+    virtual void _fixed_update_thunk(double step) {
+        fixed_update(step);
+    }
+
+private:
+    virtual void update(double dt) {}
     virtual void late_update(double dt) {}
     virtual void fixed_update(double step) {}
 };

--- a/simulant/managers.cpp
+++ b/simulant/managers.cpp
@@ -211,49 +211,17 @@ void StageManager::fixed_update(double dt) {
     }
 }
 
-void StageManager::pre_update(double dt) {
+void StageManager::late_update(double dt) {
     for(auto stage_pair: StageManager::__objects()) {
         TreeNode* root = stage_pair.second.get();
 
         root->each_descendent_and_self([=](uint32_t, TreeNode* node) {
             StageNode* stage_node = static_cast<StageNode*>(node);
-            stage_node->pre_update(dt);
+            stage_node->late_update(dt);
         });
     }
 }
 
-void StageManager::post_update(double dt) {
-    for(auto stage_pair: StageManager::__objects()) {
-        TreeNode* root = stage_pair.second.get();
-
-        root->each_descendent_and_self([=](uint32_t, TreeNode* node) {
-            StageNode* stage_node = static_cast<StageNode*>(node);
-            stage_node->post_update(dt);
-        });
-    }
-}
-
-void StageManager::pre_fixed_update(double dt) {
-    for(auto stage_pair: StageManager::__objects()) {
-        TreeNode* root = stage_pair.second.get();
-
-        root->each_descendent_and_self([=](uint32_t, TreeNode* node) {
-            StageNode* stage_node = static_cast<StageNode*>(node);
-            stage_node->pre_fixed_update(dt);
-        });
-    }
-}
-
-void StageManager::post_fixed_update(double dt) {
-    for(auto stage_pair: StageManager::__objects()) {
-        TreeNode* root = stage_pair.second.get();
-
-        root->each_descendent_and_self([=](uint32_t, TreeNode* node) {
-            StageNode* stage_node = static_cast<StageNode*>(node);
-            stage_node->post_fixed_update(dt);
-        });
-    }
-}
 
 void StageManager::update(double dt) {
     //Update the stages

--- a/simulant/managers.h
+++ b/simulant/managers.h
@@ -92,13 +92,9 @@ public:
     bool has_stage(StageID stage_id) const;
 
     void print_tree();
-    void fixed_update(double dt);
+    void fixed_update(double dt) override;
     void update(double dt) override;
-
-    void pre_update(double dt);
-    void post_update(double dt);
-    void pre_fixed_update(double step);
-    void post_fixed_update(double step);
+    void late_update(double dt) override;
 
     void delete_all_stages();
 private:

--- a/simulant/nodes/camera_proxy.cpp
+++ b/simulant/nodes/camera_proxy.cpp
@@ -83,7 +83,9 @@ void CameraProxy::_update_following(double dt) {
     }
 }
 
-void CameraProxy::post_fixed_update(double dt) {
+void CameraProxy::late_update(double dt) {
+    StageNode::late_update(dt);
+
     _update_following(dt);
 }
 

--- a/simulant/nodes/camera_proxy.h
+++ b/simulant/nodes/camera_proxy.h
@@ -52,7 +52,7 @@ private:
     CameraFollowMode following_mode_;
     float following_lag_ = 0.0;
 
-    void post_fixed_update(double dt);
+    void late_update(double dt);
 
     CameraPtr camera();
 };

--- a/simulant/nodes/stage_node.cpp
+++ b/simulant/nodes/stage_node.cpp
@@ -176,28 +176,17 @@ void StageNode::recalc_bounds() {
     }
 }
 
-void StageNode::pre_update(double dt) {
-    pre_update_controllers(dt);
-}
 
 void StageNode::update(double dt) {
     update_controllers(dt);
 }
 
-void StageNode::post_update(double dt) {
-    post_update_controllers(dt);
-}
-
-void StageNode::pre_fixed_update(double step) {
-    pre_fixed_update_controllers(step);
+void StageNode::late_update(double dt) {
+    late_update_controllers(dt);
 }
 
 void StageNode::fixed_update(double step) {
     fixed_update_controllers(step);
-}
-
-void StageNode::post_fixed_update(double step) {
-    post_fixed_update_controllers(step);
 }
 
 }

--- a/simulant/nodes/stage_node.h
+++ b/simulant/nodes/stage_node.h
@@ -69,13 +69,9 @@ public:
 
     void set_parent(CameraID id);
 
-    void pre_update(double dt) override;
     void update(double dt) override;
-    void post_update(double dt) override;
-
-    void pre_fixed_update(double step) override;
+    void late_update(double dt) override;
     void fixed_update(double step) override;
-    void post_fixed_update(double step) override;
 
     bool parent_is_stage() const { return parent() == (TreeNode*) stage_; }
 

--- a/simulant/screens/screen.cpp
+++ b/simulant/screens/screen.cpp
@@ -58,18 +58,6 @@ void ScreenBase::deactivate() {
     do_deactivate();
 }
 
-void ScreenBase::late_update(double dt) {
-    do_late_update(dt);
-}
-
-void ScreenBase::update(double dt) {
-    do_update(dt);
-}
-
-void ScreenBase::fixed_update(double step) {
-    do_fixed_update(step);
-}
-
 PipelineID ScreenBase::prepare_basic_scene(StageID& new_stage, CameraID& new_camera, AvailablePartitioner partitioner) {
     new_stage = window->new_stage(partitioner);
     new_camera = window->new_camera();

--- a/simulant/screens/screen.cpp
+++ b/simulant/screens/screen.cpp
@@ -58,8 +58,16 @@ void ScreenBase::deactivate() {
     do_deactivate();
 }
 
-void ScreenBase::step(double dt) {
-    do_step(dt);
+void ScreenBase::late_update(double dt) {
+    do_late_update(dt);
+}
+
+void ScreenBase::update(double dt) {
+    do_update(dt);
+}
+
+void ScreenBase::fixed_update(double step) {
+    do_fixed_update(step);
 }
 
 PipelineID ScreenBase::prepare_basic_scene(StageID& new_stage, CameraID& new_camera, AvailablePartitioner partitioner) {

--- a/simulant/screens/screen.h
+++ b/simulant/screens/screen.h
@@ -49,7 +49,9 @@ namespace smlt {
 
 class ScreenLoadException : public std::runtime_error {};
 
-class ScreenBase : public Nameable {
+class ScreenBase:
+    public Nameable,
+    public Updateable {
 public:
     typedef std::shared_ptr<ScreenBase> ptr;
 
@@ -62,10 +64,6 @@ public:
     void activate();
     void deactivate();
 
-    void update(double dt);
-    void late_update(double dt);
-    void fixed_update(double step);
-
     bool is_loaded() const { return is_loaded_; }
 
 protected:
@@ -75,10 +73,6 @@ protected:
     virtual void do_unload() {}
     virtual void do_activate() {}
     virtual void do_deactivate() {}
-
-    virtual void do_fixed_update(double step) {}
-    virtual void do_update(double dt) {}
-    virtual void do_late_update(double dt) {}
 
     PipelineID prepare_basic_scene(
         StageID& new_stage,

--- a/simulant/screens/screen.h
+++ b/simulant/screens/screen.h
@@ -62,7 +62,9 @@ public:
     void activate();
     void deactivate();
 
-    void step(double dt);
+    void update(double dt);
+    void late_update(double dt);
+    void fixed_update(double step);
 
     bool is_loaded() const { return is_loaded_; }
 
@@ -73,7 +75,10 @@ protected:
     virtual void do_unload() {}
     virtual void do_activate() {}
     virtual void do_deactivate() {}
-    virtual void do_step(double dt) {}
+
+    virtual void do_fixed_update(double step) {}
+    virtual void do_update(double dt) {}
+    virtual void do_late_update(double dt) {}
 
     PipelineID prepare_basic_scene(
         StageID& new_stage,

--- a/simulant/screens/screen_manager.cpp
+++ b/simulant/screens/screen_manager.cpp
@@ -35,7 +35,7 @@ ScreenManager::~ScreenManager() {
 
 void ScreenManager::fixed_update(double dt) {
     if(active_screen()) {
-        active_screen()->fixed_update(dt);
+        active_screen()->_fixed_update_thunk(dt);
     }
 }
 

--- a/simulant/screens/screen_manager.cpp
+++ b/simulant/screens/screen_manager.cpp
@@ -26,16 +26,16 @@ namespace smlt {
 ScreenManager::ScreenManager(WindowBase &window):
     window_(window) {
 
-    step_conn_ = window.signal_step().connect(std::bind(&ScreenManager::step, this, std::placeholders::_1));
+    step_conn_ = window.signal_fixed_update().connect(std::bind(&ScreenManager::fixed_update, this, std::placeholders::_1));
 }
 
 ScreenManager::~ScreenManager() {
     step_conn_.disconnect();
 }
 
-void ScreenManager::step(double dt) {
+void ScreenManager::fixed_update(double dt) {
     if(active_screen()) {
-        active_screen()->step(dt);
+        active_screen()->fixed_update(dt);
     }
 }
 

--- a/simulant/screens/screen_manager.h
+++ b/simulant/screens/screen_manager.h
@@ -108,7 +108,7 @@ private:
 
     sig::connection step_conn_;
 
-    void step(double dt);
+    void fixed_update(double step);
 };
 
 }

--- a/simulant/window_base.cpp
+++ b/simulant/window_base.cpp
@@ -272,12 +272,6 @@ void WindowBase::fixed_update(double dt) {
 
 
 void WindowBase::run_update() {
-    ktiBindTimer(variable_timer_);
-    ktiUpdateFrameTime();
-
-    delta_time_ = ktiGetDeltaTime();
-    total_time_ += delta_time_;
-
     frame_counter_time_ += delta_time_;
     frame_counter_frames_++;
 
@@ -288,11 +282,6 @@ void WindowBase::run_update() {
         frame_counter_frames_ = 0;
         frame_counter_time_ = 0.0;
     }
-
-    check_events();
-    //Update any playing sounds
-    update_source(delta_time_);
-    input_controller().update(delta_time_);
 
     update(delta_time_);
     signal_update_(delta_time_);
@@ -315,10 +304,21 @@ void WindowBase::run_fixed_updates() {
 bool WindowBase::run_frame() {
     signal_frame_started_();
 
+    ktiBindTimer(variable_timer_);
+    ktiUpdateFrameTime();
+
+    // Store the frame time, and the total elapsed time
+    delta_time_ = ktiGetDeltaTime();
+    total_time_ += delta_time_;
+
+    check_events(); // Check for any window events
+    Source::update_source(delta_time_); //Update any playing sounds
+    input_controller().update(delta_time_); // Update input devices
+    shared_assets->update(delta_time_); // Update animated assets
+
     run_fixed_updates();
     run_update();
 
-    shared_assets->update(delta_time_);
     idle_.execute(); //Execute idle tasks before render
 
     /* Don't run the render sequence if we don't have a context, and don't update the resource

--- a/simulant/window_base.cpp
+++ b/simulant/window_base.cpp
@@ -255,19 +255,19 @@ void WindowBase::set_logging_level(LoggingLevel level) {
     kazlog::get_logger("/")->set_level((kazlog::LOG_LEVEL) level);
 }
 
-void WindowBase::update(double dt) {
+void WindowBase::_update_thunk(double dt) {
     if(is_paused()) {
         dt = 0.0; //If the application window is not displayed, don't send a deltatime down
         //it's still accessible through get_deltatime if the user needs it
     }
 
     background_manager_->update(dt);
-    StageManager::update(dt);
+    StageManager::_update_thunk(dt);
 }
 
-void WindowBase::fixed_update(double dt) {
+void WindowBase::_fixed_update_thunk(double dt) {
     if(is_paused()) return;
-    StageManager::fixed_update(dt);
+    StageManager::_fixed_update_thunk(dt);
 }
 
 
@@ -283,10 +283,10 @@ void WindowBase::run_update() {
         frame_counter_time_ = 0.0;
     }
 
-    update(delta_time_);
+    _update_thunk(delta_time_);
     signal_update_(delta_time_);
 
-    late_update(delta_time_);
+    _late_update_thunk(delta_time_);
     signal_late_update_(delta_time_);
 }
 
@@ -296,7 +296,7 @@ void WindowBase::run_fixed_updates() {
     double fixed_step = ktiGetDeltaTime();
 
     while(ktiTimerCanUpdate()) {
-        fixed_update(fixed_step); // Run the fixed updates on controllers
+        _fixed_update_thunk(fixed_step); // Run the fixed updates on controllers
         signal_fixed_update_(fixed_step); //Trigger any steps
     }
 }

--- a/simulant/window_base.h
+++ b/simulant/window_base.h
@@ -101,10 +101,10 @@ private:
 typedef sig::signal<void ()> FrameStartedSignal;
 typedef sig::signal<void ()> FrameFinishedSignal;
 typedef sig::signal<void ()> PreSwapSignal;
-typedef sig::signal<void (double)> StepSignal;
-typedef sig::signal<void (double)> PostStepSignal;
 
+typedef sig::signal<void (double)> FixedUpdateSignal;
 typedef sig::signal<void (double)> UpdateSignal;
+typedef sig::signal<void (double)> LateUpdateSignal;
 
 typedef sig::signal<void ()> ShutdownSignal;
 typedef sig::signal<void (SDL_Scancode)> KeyUpSignal;
@@ -122,10 +122,9 @@ class WindowBase :
     DEFINE_SIGNAL(FrameStartedSignal, signal_frame_started);
     DEFINE_SIGNAL(FrameFinishedSignal, signal_frame_finished);
     DEFINE_SIGNAL(PreSwapSignal, signal_pre_swap);
-    DEFINE_SIGNAL(StepSignal, signal_step);
-    DEFINE_SIGNAL(PostStepSignal, signal_post_step);
-
+    DEFINE_SIGNAL(FixedUpdateSignal, signal_fixed_update);
     DEFINE_SIGNAL(UpdateSignal, signal_update);
+    DEFINE_SIGNAL(LateUpdateSignal, signal_late_update);
     DEFINE_SIGNAL(ShutdownSignal, signal_shutdown);
 
 public:    
@@ -168,6 +167,7 @@ public:
     float aspect_ratio() const { return float(width_) / float(height_); }
     
     bool run_frame();
+
     void fixed_update(double dt);
     void update(double dt) override;
 
@@ -391,6 +391,9 @@ public:
     };
 
     Property<WindowBase, Stats> stats = { this, &WindowBase::stats_ };
+
+    void run_update();
+    void run_fixed_updates();
 };
 
 }

--- a/simulant/window_base.h
+++ b/simulant/window_base.h
@@ -168,8 +168,8 @@ public:
     
     bool run_frame();
 
-    void fixed_update(double dt);
-    void update(double dt) override;
+    void _fixed_update_thunk(double dt);
+    void _update_thunk(double dt) override;
 
     Mouse& mouse();
     Joypad& joypad(uint8_t idx);


### PR DESCRIPTION
Fixes #29 

# Summary of Changes Introduced

 - Renames post_update to late_update. Drops pre_update, pre_fixed_update and post_fix_update
 - Moves update processing to after fixed_update processing
 - Exposes update, late_update and fixed_update for override on Screens and Controllers

# PR Checklist

- [ ] I have documented any changes to the code in the documentation folder
- [x] I agree that the changes introduced in this PR are dual-licensed under the LGPL
- [ ] I have added applicable tests, and not introduced any failures
