### PR TITLE
Cleanup timing across the engine

### DIFF
--- a/disabled/path_following.cpp
+++ b/disabled/path_following.cpp
@@ -45,7 +45,7 @@ public:
         return true;
     }
 
-    void update(double dt) {
+    void update(float dt) {
         set_velocity(follower_->steer_to_path());
         actor()->move_to(position() + (velocity() * dt));
     }
@@ -87,7 +87,7 @@ private:
         return true;
     }
 
-    void do_step(double dt) {
+    void do_step(float dt) {
         if(initialized()) {
             car_->update(dt);
         }

--- a/disabled/seek_sample.cpp
+++ b/disabled/seek_sample.cpp
@@ -31,7 +31,7 @@ public:
         return true;
     }
 
-    void update(double dt) {
+    void update(float dt) {
         set_velocity(follower_->seek(target));
 
         actor()->move_to(position() + (velocity() * dt));
@@ -72,7 +72,7 @@ public:
         );
     }
 
-    void do_step(double dt) {
+    void do_step(float dt) {
         dot_->update(dt);
     }
 

--- a/samples/fleets_demo.cpp
+++ b/samples/fleets_demo.cpp
@@ -26,7 +26,7 @@ public:
 
     }
 
-    void fixed_update(double dt) override {
+    void fixed_update(float dt) override {
         Vec3 speed(-250, 0, 0.0);
 
         Vec3 avg;

--- a/samples/joypad_sample.cpp
+++ b/samples/joypad_sample.cpp
@@ -151,7 +151,7 @@ public:
             });
 
 
-            auto hat_cb = [=](smlt::HatPosition position, smlt::Hat hat, double dt) mutable {
+            auto hat_cb = [=](smlt::HatPosition position, smlt::Hat hat, float dt) mutable {
                 std::cout << "Hat: " << (int) hat << std::endl;
                 std::cout << "Position " << (int) position << std::endl;
             };
@@ -164,7 +164,7 @@ public:
         }
     }
 
-    void fixed_update(double dt) {
+    void fixed_update(float dt) {
         auto actor = window->stage(stage_id_)->actor(actor_id);
         actor->rotate_x_by(smlt::Degrees(rot.y * dt * 10));
         actor->rotate_y_by(smlt::Degrees(rot.x * dt * 10));

--- a/samples/light_sample.cpp
+++ b/samples/light_sample.cpp
@@ -47,19 +47,19 @@ public:
         }
 
         float xpos = 0;
-        window->keyboard->key_while_pressed_connect(SDL_SCANCODE_A, [&](SDL_Keysym key, double dt) mutable {
+        window->keyboard->key_while_pressed_connect(SDL_SCANCODE_A, [&](SDL_Keysym key, float dt) mutable {
                 xpos -= 20.0 * dt;
                 window->stage(stage_id_)->camera(camera_id_)->move_to_absolute(xpos, 2, 0);
                 window->stage(stage_id_)->camera(camera_id_)->look_at(window->stage(stage_id_)->actor(actor_id_)->absolute_position());
         });
-        window->keyboard->key_while_pressed_connect(SDL_SCANCODE_D, [&](SDL_Keysym key, double dt) mutable {
+        window->keyboard->key_while_pressed_connect(SDL_SCANCODE_D, [&](SDL_Keysym key, float dt) mutable {
                 xpos += 20.0 * dt;
                 window->stage(stage_id_)->camera(camera_id_)->move_to_absolute(xpos, 2, 0);
                 window->stage(stage_id_)->camera(camera_id_)->look_at(window->stage(stage_id_)->actor(actor_id_)->absolute_position());
         });
     }
 
-    void fixed_update(double dt) {
+    void fixed_update(float dt) {
         window->stage(stage_id_)->actor(actor_id_)->rotate_x_by(smlt::Degrees(dt * 20.0));
         window->stage(stage_id_)->actor(actor_id_)->rotate_y_by(smlt::Degrees(dt * 15.0));
         window->stage(stage_id_)->actor(actor_id_)->rotate_z_by(smlt::Degrees(dt * 25.0));

--- a/samples/physics_demo.cpp
+++ b/samples/physics_demo.cpp
@@ -56,19 +56,19 @@ public:
         window->enable_pipeline(pipeline_id_);
 
 
-        window->keyboard->key_while_pressed_connect(SDL_SCANCODE_UP, [=](SDL_Keysym key, double dt) mutable {
+        window->keyboard->key_while_pressed_connect(SDL_SCANCODE_UP, [=](SDL_Keysym key, float dt) mutable {
             controller_->accelerate();
         });
 
-        window->keyboard->key_while_pressed_connect(SDL_SCANCODE_DOWN, [=](SDL_Keysym key, double dt) mutable {
+        window->keyboard->key_while_pressed_connect(SDL_SCANCODE_DOWN, [=](SDL_Keysym key, float dt) mutable {
             controller_->decelerate();
         });
 
-        window->keyboard->key_while_pressed_connect(SDL_SCANCODE_RIGHT, [=](SDL_Keysym key, double dt) mutable {
+        window->keyboard->key_while_pressed_connect(SDL_SCANCODE_RIGHT, [=](SDL_Keysym key, float dt) mutable {
             controller_->turn_left();
         });
 
-        window->keyboard->key_while_pressed_connect(SDL_SCANCODE_LEFT, [=](SDL_Keysym key, double dt) mutable {
+        window->keyboard->key_while_pressed_connect(SDL_SCANCODE_LEFT, [=](SDL_Keysym key, float dt) mutable {
             controller_->turn_right();
         });
     }

--- a/samples/rtt_sample.cpp
+++ b/samples/rtt_sample.cpp
@@ -31,7 +31,7 @@ public:
         ).with_clear();
     }
 
-    void fixed_update(double dt) {
+    void fixed_update(float dt) {
         window->stage(cube_stage_)->actor(cube_)->rotate_y_by(Degrees(dt * 360));
         window->stage(rect_stage_)->actor(rect_)->rotate_y_by(Degrees(dt * 180));
     }

--- a/samples/terrain_sample.cpp
+++ b/samples/terrain_sample.cpp
@@ -95,7 +95,7 @@ public:
         window->enable_pipeline(pipeline_id_);
     }
 
-    void fixed_update(double dt) override {
+    void fixed_update(float dt) override {
         auto stage = window->stage(stage_id_);
         stage->actor(terrain_actor_id_)->rotate_global_y_by(smlt::Degrees(dt * 5.0));
     }

--- a/simulant.files
+++ b/simulant.files
@@ -1548,3 +1548,5 @@ simulant/controllers/movement/smooth_follow.h
 simulant/controllers/stage_node_controller.h
 simulant/controllers/movement/smooth_follow.cpp
 simulant/scenes/physics_scene.h
+simulant/time_keeper.h
+simulant/time_keeper.cpp

--- a/simulant/animation.cpp
+++ b/simulant/animation.cpp
@@ -118,7 +118,7 @@ void KeyFrameAnimationState::override_playing_animation_duration(const float new
     current_animation_duration_ = new_duration;
 }
 
-void KeyFrameAnimationState::update(double dt) {
+void KeyFrameAnimationState::update(float dt) {
     if(!current_animation_){
         return;
     }

--- a/simulant/animation.h
+++ b/simulant/animation.h
@@ -92,7 +92,7 @@ public:
     void play_sequence(const std::string& name);
 
     void override_playing_animation_duration(const float new_duration);
-    void update(double dt);
+    void update(float dt);
 
     uint32_t current_frame() const { return current_frame_; }
     uint32_t next_frame() const { return next_frame_; }

--- a/simulant/application.h
+++ b/simulant/application.h
@@ -106,7 +106,7 @@ private:
     bool initialized_ = false;
 
     virtual bool do_init() = 0;
-    virtual void do_fixed_update(double dt) {}
+    virtual void do_fixed_update(float dt) {}
     virtual void do_cleanup() {}
 
     virtual bool while_key_pressed(SDL_Keysym key, double) { return false; }

--- a/simulant/background.cpp
+++ b/simulant/background.cpp
@@ -94,7 +94,7 @@ void Background::cleanup() {
     manager_->window->delete_camera(camera_id_);
 }
 
-void Background::update(double dt) {
+void Background::update(float dt) {
     auto pass = manager_->window->stage(stage_id_)->assets->material(material_id_)->first_pass();
     if(pass->texture_unit_count()) {
         pass->texture_unit(0).scroll_x(x_rate_ * dt);

--- a/simulant/background.h
+++ b/simulant/background.h
@@ -49,7 +49,7 @@ public:
 
     bool init() override;
     void cleanup() override;
-    void update(double dt) override;
+    void update(float dt) override;
 
     void set_horizontal_scroll_rate(float x_rate);
     void set_vertical_scroll_rate(float y_rate);

--- a/simulant/controllers/controller.cpp
+++ b/simulant/controllers/controller.cpp
@@ -10,7 +10,7 @@ void Controller::disable() {
     is_enabled_ = false;
 }
 
-void Controller::_update_thunk(double dt) {
+void Controller::_update_thunk(float dt) {
     if(!is_enabled_) {
         return;
     }
@@ -18,7 +18,7 @@ void Controller::_update_thunk(double dt) {
     Updateable::_update_thunk(dt);
 }
 
-void Controller::_late_update_thunk(double dt) {
+void Controller::_late_update_thunk(float dt) {
     if(!is_enabled_) {
         return;
     }
@@ -26,7 +26,7 @@ void Controller::_late_update_thunk(double dt) {
     Updateable::_late_update_thunk(dt);
 }
 
-void Controller::_fixed_update_thunk(double step) {
+void Controller::_fixed_update_thunk(float step) {
     if(!is_enabled_) {
         return;
     }

--- a/simulant/controllers/controller.h
+++ b/simulant/controllers/controller.h
@@ -50,9 +50,9 @@ public:
     void enable();
     void disable();
 
-    void _update_thunk(double dt) override;
-    void _late_update_thunk(double dt) override;
-    void _fixed_update_thunk(double step) override;
+    void _update_thunk(float dt) override;
+    void _late_update_thunk(float dt) override;
+    void _fixed_update_thunk(float step) override;
 
 private:
     bool is_enabled_ = true;
@@ -111,19 +111,19 @@ public:
         return ret;
     }
 
-    void fixed_update_controllers(double step) {
+    void fixed_update_controllers(float step) {
         for(auto& controller: controllers_) {
             controller->_fixed_update_thunk(step);
         }
     }
 
-    void update_controllers(double dt) {
+    void update_controllers(float dt) {
         for(auto& controller: controllers_) {
             controller->_update_thunk(dt);
         }
     }
 
-    void late_update_controllers(double dt) {
+    void late_update_controllers(float dt) {
         for(auto& controller: controllers_) {
             controller->_late_update_thunk(dt);
         }

--- a/simulant/controllers/fly.h
+++ b/simulant/controllers/fly.h
@@ -47,19 +47,19 @@ public:
             throw std::logic_error("Tried to attach FlyController to something which wasn't an object");
         }
 
-        connections_.push_back(window->keyboard->key_while_pressed_connect(SDL_SCANCODE_W, [=](SDL_Keysym key, double dt) {
+        connections_.push_back(window->keyboard->key_while_pressed_connect(SDL_SCANCODE_W, [=](SDL_Keysym key, float dt) {
             moving_forward_ = true;
         }));
 
-        connections_.push_back(window->keyboard->key_while_pressed_connect(SDL_SCANCODE_S, [=](SDL_Keysym key, double dt) {
+        connections_.push_back(window->keyboard->key_while_pressed_connect(SDL_SCANCODE_S, [=](SDL_Keysym key, float dt) {
             moving_backward_ = true;
         }));
 
-        connections_.push_back(window->keyboard->key_while_pressed_connect(SDL_SCANCODE_A, [=](SDL_Keysym key, double dt) {
+        connections_.push_back(window->keyboard->key_while_pressed_connect(SDL_SCANCODE_A, [=](SDL_Keysym key, float dt) {
             rotating_left_ = true;
         }));
 
-        connections_.push_back(window->keyboard->key_while_pressed_connect(SDL_SCANCODE_D, [=](SDL_Keysym key, double dt) {
+        connections_.push_back(window->keyboard->key_while_pressed_connect(SDL_SCANCODE_D, [=](SDL_Keysym key, float dt) {
             rotating_right_ = true;
         }));
 
@@ -86,7 +86,7 @@ public:
     const std::string name() const override { return "Fly by Keyboard"; }
 
 private:
-    void late_update(double dt) override {
+    void late_update(float dt) override {
         if(moving_forward_) {
             object_->move_forward_by(600.0 * dt);
         }

--- a/simulant/controllers/material/flowing.cpp
+++ b/simulant/controllers/material/flowing.cpp
@@ -24,7 +24,7 @@ namespace smlt {
 namespace controllers {
 namespace material {
 
-void Flowing::update(double dt) {
+void Flowing::update(float dt) {
     float scroll = -(time_ - int(time_));
 
     auto pass = material->pass(0);

--- a/simulant/controllers/material/flowing.h
+++ b/simulant/controllers/material/flowing.h
@@ -38,7 +38,7 @@ public:
 
     const std::string name() const override { return "Flowing Material"; }
 private:
-    void update(double dt) override;
+    void update(float dt) override;
     double time_ = 0.0f;
 };
 

--- a/simulant/controllers/material/warp.cpp
+++ b/simulant/controllers/material/warp.cpp
@@ -24,7 +24,7 @@ namespace smlt {
 namespace controllers {
 namespace material {
 
-void Warp::update(double dt) {
+void Warp::update(float dt) {
     auto pass = material->pass(0);
     auto& tex_unit = pass->texture_unit(0);
 

--- a/simulant/controllers/material/warp.h
+++ b/simulant/controllers/material/warp.h
@@ -40,7 +40,7 @@ public:
     const std::string name() const { return "Warped Material"; }
 
 private:
-    void update(double dt) override;
+    void update(float dt) override;
     double time_ = 0.0f;
 };
 

--- a/simulant/controllers/movement/smooth_follow.cpp
+++ b/simulant/controllers/movement/smooth_follow.cpp
@@ -11,7 +11,7 @@ SmoothFollow::SmoothFollow(Controllable* controllable):
 
 }
 
-void SmoothFollow::late_update(double dt) {
+void SmoothFollow::late_update(float dt) {
     auto target = target_.lock();
 
     if(!target) {

--- a/simulant/controllers/movement/smooth_follow.h
+++ b/simulant/controllers/movement/smooth_follow.h
@@ -21,7 +21,7 @@ public:
         return "Smooth Follow";
     }
 
-    void late_update(double dt) override;
+    void late_update(float dt) override;
     void set_target(ActorPtr actor);
     void set_target(ParticleSystemPtr ps);
 

--- a/simulant/controllers/raycast_vehicle.cpp
+++ b/simulant/controllers/raycast_vehicle.cpp
@@ -69,7 +69,7 @@ bool RaycastVehicle::init() {
     }
 }
 
-void RaycastVehicle::fixed_update(double dt) {
+void RaycastVehicle::fixed_update(float dt) {
     RigidBodySimulation* sim = simulation;
     if(!sim) {
         return;

--- a/simulant/controllers/raycast_vehicle.h
+++ b/simulant/controllers/raycast_vehicle.h
@@ -100,8 +100,8 @@ private:
     float turn_force_ = 0.0f;
     float drive_force_ = 0.0f;
 
-    void fixed_update(double dt) override;
-    void pre_update(double dt) {
+    void fixed_update(float dt) override;
+    void pre_update(float dt) {
         // Before we read any input or anything, clear the forces
         drive_force_ = 0.0f;
         turn_force_ = 0.0f;

--- a/simulant/controllers/rigid_body.h
+++ b/simulant/controllers/rigid_body.h
@@ -26,6 +26,7 @@
 #include "../types.h"
 #include "../interfaces/transformable.h"
 #include "../deps/qu3e/q3.h"
+#include "../time_keeper.h"
 
 namespace smlt {
 
@@ -113,19 +114,22 @@ class RigidBodySimulation:
     public std::enable_shared_from_this<RigidBodySimulation> {
 
 public:
-    RigidBodySimulation();
+    RigidBodySimulation(TimeKeeper* time_keeper);
     bool init() override;
     void cleanup() override;
 
-    void fixed_update(double dt);
+    void fixed_update(float dt);
 
     std::pair<Vec3, bool> intersect_ray(const Vec3& start, const Vec3& direction, float* distance=nullptr, Vec3 *normal=nullptr);
 
     void set_gravity(const Vec3& gravity);
+
 private:
     friend class impl::Body;
     friend class RigidBody;
     friend class StaticBody;
+
+    TimeKeeper* time_keeper_ = nullptr;
 
     q3Scene* scene_ = nullptr;
 
@@ -182,7 +186,9 @@ namespace impl {
         std::weak_ptr<RigidBodySimulation> simulation_;
         ColliderType collider_type_;
 
-        void update(double dt) override;
+        std::pair<Vec3, Quaternion> last_state_;
+
+        void update(float dt) override;
 
         void build_collider(ColliderType collider);
 

--- a/simulant/debug.cpp
+++ b/simulant/debug.cpp
@@ -39,7 +39,7 @@ Debug::~Debug() {
 }
 
 void Debug::update() {
-    double dt = stage_.window->delta_time();
+    float dt = stage_.window->time_keeper->delta_time();
 
     std::vector<DebugElement> to_keep;
 

--- a/simulant/idle_task_manager.cpp
+++ b/simulant/idle_task_manager.cpp
@@ -70,7 +70,7 @@ struct TimedTrigger {
     }
 
     bool update(smlt::WindowBase* window) {
-        auto now = window->total_time();
+        auto now = window->time_keeper->total_elapsed_seconds();
         if(!start_time_) {
             start_time_ = now;
         }

--- a/simulant/input_controller.cpp
+++ b/simulant/input_controller.cpp
@@ -158,7 +158,7 @@ void Keyboard::_handle_keyup_event(SDL_Keysym key) {
 
 }
 
-void Keyboard::_update(double dt) {
+void Keyboard::_update(float dt) {
     for(auto keysym: keys_down_) {
         for(auto conn: global_while_key_pressed_signals_) {
             conn.second(keysym.second, dt);
@@ -296,7 +296,7 @@ void Joypad::_handle_hat_changed_event(Hat hat, HatPosition position) {
     hat_state_[hat] = position;
 }
 
-void Joypad::_update(double dt) {
+void Joypad::_update(float dt) {
     for(std::pair<JoypadAxis, int32_t> p: axis_state_) {
         JoypadAxis axis = p.first;
         int32_t axis_state = p.second;
@@ -418,7 +418,7 @@ void InputController::handle_event(SDL_Event &event) {
     }
 }
 
-void InputController::update(double dt) {
+void InputController::update(float dt) {
     keyboard_->_update(dt);
     mouse_->_update(dt);
 
@@ -493,7 +493,7 @@ void Mouse::_disconnect(const InputConnection &connection) {
     motion_event_signals_.erase(connection);
 }
 
-void Mouse::_update(double dt) {
+void Mouse::_update(float dt) {
     for(auto& entry: this->motion_event_signals_) {
         entry.second(
             last_motion_event_.x,

--- a/simulant/input_controller.h
+++ b/simulant/input_controller.h
@@ -109,7 +109,7 @@ private:
     void _handle_keyup_event(SDL_Keysym key);
     void _handle_text_input_event(SDL_TextInputEvent key);
 
-    void _update(double dt);
+    void _update(float dt);
     void _disconnect(const InputConnection &connection);
 
     std::map<SDL_Scancode, bool> state_;
@@ -157,7 +157,7 @@ private:
     std::map<InputConnection, MouseMotionCallback> motion_event_signals_;
 
     void _disconnect(const InputConnection &connection) override;
-    void _update(double dt);
+    void _update(float dt);
     void _handle_motion_event(int32_t x, int32_t y, int32_t relx, int32_t rely);
 
     struct MotionEvent {
@@ -226,7 +226,7 @@ private:
     void _handle_button_up_event(Button button);
     void _handle_hat_changed_event(Hat hat, HatPosition value);
 
-    void _update(double dt);
+    void _update(float dt);
     void _disconnect(const InputConnection &connection);
 
     uint8_t jitter_value_;
@@ -262,7 +262,7 @@ public:
     Joypad& joypad(uint8_t idx=0);
     uint8_t joypad_count() const;
 
-    void update(double dt);
+    void update(float dt);
     void handle_event(SDL_Event& event);
 
 private:

--- a/simulant/interfaces/updateable.h
+++ b/simulant/interfaces/updateable.h
@@ -17,22 +17,22 @@ public:
      * Non-Virtual Interface. Simulant calls these underscore prefixed
      * functions, and subclasses implement the more nicely named ones
      */
-    virtual void _update_thunk(double dt) {
+    virtual void _update_thunk(float dt) {
         update(dt);
     }
 
-    virtual void _late_update_thunk(double dt) {
+    virtual void _late_update_thunk(float dt) {
         late_update(dt);
     }
 
-    virtual void _fixed_update_thunk(double step) {
+    virtual void _fixed_update_thunk(float step) {
         fixed_update(step);
     }
 
 private:
-    virtual void update(double dt) {}
-    virtual void late_update(double dt) {}
-    virtual void fixed_update(double step) {}
+    virtual void update(float dt) {}
+    virtual void late_update(float dt) {}
+    virtual void fixed_update(float step) {}
 };
 
 }

--- a/simulant/managers.cpp
+++ b/simulant/managers.cpp
@@ -44,7 +44,7 @@ BackgroundManager::~BackgroundManager() {
     }
 }
 
-void BackgroundManager::update(double dt) {
+void BackgroundManager::update(float dt) {
     //Update the backgrounds
     for(auto background_pair: BackgroundManager::__objects()) {
         auto* bg = background_pair.second.get();
@@ -200,7 +200,7 @@ void StageManager::delete_stage(StageID s) {
     signal_stage_removed_(s);
 }
 
-void StageManager::fixed_update(double dt) {
+void StageManager::fixed_update(float dt) {
     for(auto stage_pair: StageManager::__objects()) {
         TreeNode* root = stage_pair.second.get();
 
@@ -211,7 +211,7 @@ void StageManager::fixed_update(double dt) {
     }
 }
 
-void StageManager::late_update(double dt) {
+void StageManager::late_update(float dt) {
     for(auto stage_pair: StageManager::__objects()) {
         TreeNode* root = stage_pair.second.get();
 
@@ -223,7 +223,7 @@ void StageManager::late_update(double dt) {
 }
 
 
-void StageManager::update(double dt) {
+void StageManager::update(float dt) {
     //Update the stages
     for(auto stage_pair: StageManager::__objects()) {
         TreeNode* root = stage_pair.second.get();

--- a/simulant/managers.h
+++ b/simulant/managers.h
@@ -45,7 +45,7 @@ public:
     void delete_background(BackgroundID bid);
     uint32_t background_count() const;
 
-    void update(double dt) override;
+    void update(float dt) override;
 
     Property<BackgroundManager, WindowBase> window = { this, &BackgroundManager::window_ };
 private:
@@ -92,9 +92,9 @@ public:
     bool has_stage(StageID stage_id) const;
 
     void print_tree();
-    void fixed_update(double dt) override;
-    void update(double dt) override;
-    void late_update(double dt) override;
+    void fixed_update(float dt) override;
+    void update(float dt) override;
+    void late_update(float dt) override;
 
     void delete_all_stages();
 private:

--- a/simulant/managers/skybox_manager.h
+++ b/simulant/managers/skybox_manager.h
@@ -68,7 +68,7 @@ public:
 
     const AABB aabb() const;
 
-    void update(double step) {}
+    void update(float step) {}
 private:
     friend class SkyboxManager;
 

--- a/simulant/material.cpp
+++ b/simulant/material.cpp
@@ -237,7 +237,7 @@ void Material::set_texture_unit_on_all_passes(uint32_t texture_unit_id, TextureI
     }
 }
 
-void Material::update(double dt) {
+void Material::update(float dt) {
     // The updating_disabled_ flag wasn't set so we
     // can safely update
     if(!updating_disabled_.test_and_set()) {

--- a/simulant/material.h
+++ b/simulant/material.h
@@ -64,7 +64,7 @@ public:
 
     TextureID texture_id() const;
 
-    void update(double dt) {
+    void update(float dt) {
         if(!is_animated()) return;
 
         time_elapsed_ += dt;
@@ -169,7 +169,7 @@ public:
     TextureUnit& texture_unit(uint32_t index) { return texture_units_.at(index); }
     const TextureUnit& texture_unit(uint32_t index) const { return texture_units_.at(index); }
 
-    void update(double dt) {
+    void update(float dt) {
         for(TextureUnit& t: texture_units_) {
             t.update(dt);
         }
@@ -290,7 +290,7 @@ public:
     Material(MaterialID mat_id, ResourceManager* resource_manager);
     ~Material();
 
-    void update(double dt) override;
+    void update(float dt) override;
     bool has_reflective_pass() const { return !reflective_passes_.empty(); }
 
     uint32_t new_pass();

--- a/simulant/nodes/actor.cpp
+++ b/simulant/nodes/actor.cpp
@@ -181,7 +181,7 @@ void Actor::set_mesh(MeshID mesh) {
     signal_mesh_changed_(id());
 }
 
-void Actor::update(double dt) {
+void Actor::update(float dt) {
     StageNode::update(dt);
 
     update_source(dt);

--- a/simulant/nodes/actor.h
+++ b/simulant/nodes/actor.h
@@ -129,7 +129,7 @@ private:
     SubActorMaterialChangedCallback signal_subactor_material_changed_;
     MeshChangedCallback signal_mesh_changed_;
 
-    void update(double dt) override;
+    void update(float dt) override;
     void clear_subactors();
     void rebuild_subactors();
     sig::connection submesh_created_connection_;

--- a/simulant/nodes/camera_proxy.cpp
+++ b/simulant/nodes/camera_proxy.cpp
@@ -49,7 +49,7 @@ smlt::optional<Vec3> CameraProxy::project_point(const RenderTarget& target, cons
     return camera()->project_point(target, viewport, point);
 }
 
-void CameraProxy::update(double step) {
+void CameraProxy::update(float step) {
     StageNode::update(step);
 
     // Update the associated camera with this transformation

--- a/simulant/nodes/camera_proxy.h
+++ b/simulant/nodes/camera_proxy.h
@@ -24,7 +24,7 @@ public:
 
     void set_orthographic_projection(double left, double right, double bottom, double top, double near=-1.0, double far=1.0);
 
-    void update(double step) override;
+    void update(float step) override;
 
     /* Camera Proxies have no mass/body so their AABB is just 0,0,0, or their position */
     const AABB aabb() const {

--- a/simulant/nodes/geom.h
+++ b/simulant/nodes/geom.h
@@ -83,7 +83,7 @@ private:
     std::shared_ptr<Mesh> mesh_;
     RenderPriority render_priority_;
 
-    void update(double dt) {
+    void update(float dt) {
         update_source(dt);
     }
 

--- a/simulant/nodes/light.h
+++ b/simulant/nodes/light.h
@@ -100,7 +100,7 @@ public:
     void ask_owner_for_destruction();
     RenderableCullingMode renderable_culling_mode() const { return culling_mode_; }
 
-    void update(double step) override {}
+    void update(float step) override {}
 
     void cleanup() override {
         StageNode::cleanup();

--- a/simulant/nodes/particles.cpp
+++ b/simulant/nodes/particles.cpp
@@ -187,7 +187,7 @@ void ParticleEmitter::deactivate() {
     is_active_ = false;
 }
 
-void ParticleEmitter::update(double dt) {
+void ParticleEmitter::update(float dt) {
     time_active_ += dt;
 
     if(current_duration_ && time_active_ >= current_duration_) {
@@ -213,7 +213,7 @@ void ParticleSystem::set_quota(int quota) {
     vertex_buffer_dirty_ = index_buffer_dirty_ = true;
 }
 
-void ParticleSystem::update(double dt) {
+void ParticleSystem::update(float dt) {
     update_source(dt); //Update any sounds attached to this particle system
 
     auto current_particle_count = particles_.size();
@@ -280,7 +280,7 @@ void ParticleSystem::update(double dt) {
     index_data_->done();
 }
 
-std::vector<Particle> ParticleEmitter::do_emit(double dt, uint32_t max) {
+std::vector<Particle> ParticleEmitter::do_emit(float dt, uint32_t max) {
     std::vector<Particle> new_particles;
 
     if(!max) {

--- a/simulant/nodes/particles.h
+++ b/simulant/nodes/particles.h
@@ -110,11 +110,11 @@ public:
     void set_duration_range(float min_seconds, float max_seconds);
     std::pair<float, float> duration_range() const;
 
-    std::vector<Particle> do_emit(double dt, uint32_t max_to_emit);
+    std::vector<Particle> do_emit(float dt, uint32_t max_to_emit);
 
     ParticleSystem& system() { return system_; }
 
-    void update(double dt);
+    void update(float dt);
 
     void activate();
     void deactivate();
@@ -256,7 +256,7 @@ private:
     std::vector<EmitterPtr> emitters_;
     std::list<Particle> particles_;
 
-    void update(double dt) override;
+    void update(float dt) override;
 
     VertexData* vertex_data_ = nullptr;
     IndexData* index_data_ = nullptr;

--- a/simulant/nodes/sprite.cpp
+++ b/simulant/nodes/sprite.cpp
@@ -63,7 +63,7 @@ void Sprite::ask_owner_for_destruction() {
     stage->delete_sprite(id());
 }
 
-void Sprite::update(double dt) {
+void Sprite::update(float dt) {
     if(actor_id_) {
         stage->actor(actor_id_)->set_parent(this); //Make sure every frame that our actor stays attached to us!
     }

--- a/simulant/nodes/sprite.h
+++ b/simulant/nodes/sprite.h
@@ -46,7 +46,7 @@ public:
 
     bool init() override;
     void cleanup() override;
-    void update(double dt) override;
+    void update(float dt) override;
 
     Sprite(SpriteID id, Stage* stage);
 

--- a/simulant/nodes/stage_node.cpp
+++ b/simulant/nodes/stage_node.cpp
@@ -177,15 +177,15 @@ void StageNode::recalc_bounds() {
 }
 
 
-void StageNode::update(double dt) {
+void StageNode::update(float dt) {
     update_controllers(dt);
 }
 
-void StageNode::late_update(double dt) {
+void StageNode::late_update(float dt) {
     late_update_controllers(dt);
 }
 
-void StageNode::fixed_update(double step) {
+void StageNode::fixed_update(float step) {
     fixed_update_controllers(step);
 }
 

--- a/simulant/nodes/stage_node.h
+++ b/simulant/nodes/stage_node.h
@@ -69,9 +69,9 @@ public:
 
     void set_parent(CameraID id);
 
-    void update(double dt) override;
-    void late_update(double dt) override;
-    void fixed_update(double step) override;
+    void update(float dt) override;
+    void late_update(float dt) override;
+    void fixed_update(float step) override;
 
     bool parent_is_stage() const { return parent() == (TreeNode*) stage_; }
 

--- a/simulant/nodes/ui/progress_bar.cpp
+++ b/simulant/nodes/ui/progress_bar.cpp
@@ -34,7 +34,7 @@ void ProgressBar::refresh_pulse() {
     float pulse_max = pulse_range / 2.0f;
     float pulse_min = -pulse_range / 2.0f;
 
-    float dt = stage->window->delta_time();
+    float dt = stage->window->time_keeper->delta_time();
 
     if(pulse_right_) {
         pulse_position_ += pulse_step_ * dt;

--- a/simulant/panels/stats_panel.cpp
+++ b/simulant/panels/stats_panel.cpp
@@ -86,7 +86,7 @@ void StatsPanel::update() {
     static float last_update = 0.0f;
     static bool first_update = true;
 
-    last_update += window_->delta_time();
+    last_update += window_->time_keeper->delta_time();
 
     if(first_update || last_update >= 1.0) {
         auto mem_usage = get_memory_usage_in_megabytes();

--- a/simulant/resource_manager.cpp
+++ b/simulant/resource_manager.cpp
@@ -82,7 +82,7 @@ bool ResourceManager::init() {
     return true;
 }
 
-void ResourceManager::update(double dt) {
+void ResourceManager::update(float dt) {
     MaterialManager::each([dt](Material* mat) {
         mat->update_controllers(dt);
         mat->update(dt);

--- a/simulant/resource_manager.h
+++ b/simulant/resource_manager.h
@@ -177,7 +177,7 @@ public:
     bool has_font(FontID f) const;
     void mark_font_as_uncollected(FontID f);
 
-    void update(double dt);
+    void update(float dt);
 
     unicode default_material_filename() const;
     unicode default_font_filename() const;

--- a/simulant/scenes/physics_scene.h
+++ b/simulant/scenes/physics_scene.h
@@ -15,7 +15,7 @@ protected:
 
     Property<PhysicsScene, smlt::controllers::RigidBodySimulation> physics = { this, &PhysicsScene::physics_ };
 
-    virtual void _fixed_update_thunk(double step) {
+    virtual void _fixed_update_thunk(float step) {
         Scene<T>::_fixed_update_thunk(step);
         if(physics_) {
             physics_->fixed_update(step);
@@ -24,7 +24,7 @@ protected:
 
 private:
     void pre_load() override {
-        physics_.reset(new smlt::controllers::RigidBodySimulation());
+        physics_.reset(new smlt::controllers::RigidBodySimulation(this->window_->time_keeper));
     }
 
     void post_unload() override {

--- a/simulant/scenes/scene_manager.cpp
+++ b/simulant/scenes/scene_manager.cpp
@@ -37,19 +37,19 @@ SceneManager::~SceneManager() {
     late_update_conn_.disconnect();
 }
 
-void SceneManager::late_update(double dt) {
+void SceneManager::late_update(float dt) {
     if(active_scene()) {
         active_scene()->_late_update_thunk(dt);
     }
 }
 
-void SceneManager::update(double dt) {
+void SceneManager::update(float dt) {
     if(active_scene()) {
         active_scene()->_update_thunk(dt);
     }
 }
 
-void SceneManager::fixed_update(double dt) {
+void SceneManager::fixed_update(float dt) {
     if(active_scene()) {
         active_scene()->_fixed_update_thunk(dt);
     }

--- a/simulant/scenes/scene_manager.h
+++ b/simulant/scenes/scene_manager.h
@@ -121,9 +121,9 @@ private:
     sig::connection update_conn_;
     sig::connection late_update_conn_;
 
-    void update(double dt);
-    void late_update(double dt);
-    void fixed_update(double step);
+    void update(float dt);
+    void late_update(float dt);
+    void fixed_update(float step);
 };
 
 }

--- a/simulant/stage.cpp
+++ b/simulant/stage.cpp
@@ -381,7 +381,7 @@ void Stage::set_partitioner(AvailablePartitioner partitioner) {
     signal_particle_system_destroyed().connect(std::bind(&Partitioner::remove_particle_system, partitioner_.get(), std::placeholders::_1));
 }
 
-void Stage::update(double dt) {
+void Stage::update(float dt) {
     resource_manager_->update(dt);
 }
 

--- a/simulant/stage.h
+++ b/simulant/stage.h
@@ -184,7 +184,7 @@ public:
 
     // Updateable interface
 
-    void update(double dt) override;
+    void update(float dt) override;
 
     // RenderableStage
     void on_render_started() override {}

--- a/simulant/time_keeper.cpp
+++ b/simulant/time_keeper.cpp
@@ -1,0 +1,50 @@
+
+#include "time_keeper.h"
+
+namespace smlt {
+
+TimeKeeper::TimeKeeper(const float fixed_step):
+    fixed_step_(fixed_step) {
+
+}
+
+bool TimeKeeper::init() {
+    ktiGenTimers(1, &fixed_timer_);
+    ktiBindTimer(fixed_timer_);
+    ktiStartFixedStepTimer(1.0f / fixed_step_);
+
+    ktiGenTimers(1, &variable_timer_);
+    ktiBindTimer(variable_timer_);
+    ktiStartGameTimer();
+
+    return true;
+}
+
+void TimeKeeper::cleanup() {
+    ktiDeleteTimers(1, &fixed_timer_);
+    ktiDeleteTimers(1, &variable_timer_);
+}
+
+void TimeKeeper::update() {
+    ktiBindTimer(fixed_timer_);
+    ktiUpdateFrameTime();
+
+    ktiBindTimer(variable_timer_);
+    ktiUpdateFrameTime();
+
+    // Store the frame time, and the total elapsed time
+    delta_time_ = ktiGetDeltaTime();
+    total_time_ += delta_time_;
+}
+
+float TimeKeeper::fixed_step_remainder() const {
+    ktiBindTimer(fixed_timer_);
+    return ktiGetAccumulatorValue();
+}
+
+bool TimeKeeper::use_fixed_step() {
+    ktiBindTimer(fixed_timer_);
+    return ktiTimerCanUpdate();
+}
+
+}

--- a/simulant/time_keeper.h
+++ b/simulant/time_keeper.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "deps/kaztimer/kaztimer.h"
+#include "generic/managed.h"
+
+namespace smlt {
+
+class TimeKeeper:
+    public Managed<TimeKeeper> {
+
+public:
+    TimeKeeper(const float fixed_step = 1.0 / 6.0f);
+
+    bool init() override;
+    void cleanup() override;
+
+    void update();
+
+    float delta_time() const { return delta_time_; }
+    float fixed_step() const { return fixed_step_; }
+    float fixed_step_remainder() const;
+    float total_elapsed_seconds() const { return total_time_; }
+
+    bool use_fixed_step();
+
+private:
+    float total_time_ = 0.0f;
+    float delta_time_ = 0.0f;
+    float fixed_step_ = 0.0f;
+
+    KTIuint fixed_timer_ = 0;
+    KTIuint variable_timer_ = 0;
+};
+
+}

--- a/simulant/window_base.h
+++ b/simulant/window_base.h
@@ -41,6 +41,7 @@
 #include "scenes/scene_manager.h"
 #include "loader.h"
 #include "event_listener.h"
+#include "time_keeper.h"
 
 
 namespace smlt {
@@ -156,10 +157,6 @@ public:
     virtual void check_events() = 0;
     virtual void swap_buffers() = 0;
 
-    double delta_time() const { return delta_time_; }
-    double total_time() const { return total_time_; }
-    double fixed_step() const { return 1.0 / double(WindowBase::STEPS_PER_SECOND); }
-    double fixed_step_interp() const;
     bool is_paused() const { return is_paused_; }
 
     uint32_t width() const override { return width_; }
@@ -168,8 +165,8 @@ public:
     
     bool run_frame();
 
-    void _fixed_update_thunk(double dt);
-    void _update_thunk(double dt) override;
+    void _fixed_update_thunk(float dt);
+    void _update_thunk(float dt) override;
 
     Mouse& mouse();
     Joypad& joypad(uint8_t idx);
@@ -318,10 +315,6 @@ private:
         
     IdleTaskManager idle_;
 
-    KTIuint fixed_timer_;
-    KTIuint variable_timer_;
-    double delta_time_;
-    double fixed_step_interp_ = 0.0;
     bool is_paused_ = false;
     bool has_context_ = false;
 
@@ -349,8 +342,6 @@ private:
     int32_t frame_counter_frames_;
     double frame_time_in_milliseconds_;
 
-    double total_time_ = 0.0;
-
     std::shared_ptr<Watcher> watcher_;
     std::shared_ptr<scenes::Loading> loading_;
     std::shared_ptr<smlt::RenderSequence> render_sequence_;
@@ -358,6 +349,7 @@ private:
 
     std::shared_ptr<VirtualGamepad> virtual_gamepad_;
     std::unique_ptr<BackgroundManager> background_manager_;
+    std::shared_ptr<TimeKeeper> time_keeper_;
 
     Stats stats_;
 
@@ -368,6 +360,7 @@ public:
     Property<WindowBase, Application> application = { this, &WindowBase::application_ };
     Property<WindowBase, VirtualGamepad> virtual_joypad = { this, &WindowBase::virtual_gamepad_ };
     Property<WindowBase, Renderer> renderer = { this, &WindowBase::renderer_ };
+    Property<WindowBase, TimeKeeper> time_keeper = { this, &WindowBase::time_keeper_ };
 
     Property<WindowBase, Watcher> watcher = {
         this, [](const WindowBase* self) -> Watcher* {

--- a/tests/test_rigid_body.h
+++ b/tests/test_rigid_body.h
@@ -14,7 +14,7 @@ public:
 
         auto mesh_id = window->shared_assets->new_mesh_as_box(50, 1, 50);
 
-        auto simulation = smlt::controllers::RigidBodySimulation::create();
+        auto simulation = smlt::controllers::RigidBodySimulation::create(window->time_keeper);
 
         auto actor_id = stage->new_actor_with_mesh(mesh_id);
         auto actor = stage->actor(actor_id);

--- a/tests/test_virtual_gamepad.h
+++ b/tests/test_virtual_gamepad.h
@@ -248,7 +248,7 @@ public:
         float x = b1.min.x + 1;
         float y = b1.min.y + 1;
 
-        window->joypad(window->joypad_count() - 1).button_while_down_connect(0, [&](int btn, double dt) {
+        window->joypad(window->joypad_count() - 1).button_while_down_connect(0, [&](int btn, float dt) {
             button_pressed = true;
         });
 


### PR DESCRIPTION
# Summary of Changes Introduced

- Moved time functions from WindowBase -> TimeKeeper
- WindowBase now has a `time_keeper` Property
- The Window's TimeKeeper instance is now passed to RigidBodySimulation
- Implemented interpolation in the rigid body controller
- Switched `double` to `float` for all delta time and step values (unnecessary precision)
- Removed `WindowBase::total_time()`, `WindowBase::delta_time()` etc. replaced with `time_keeper->total_elapsed_seconds()` etc.

# PR Checklist

- [ ] I have documented any changes to the code in the documentation folder
- [x] I agree that the changes introduced in this PR are dual-licensed under the LGPL
- [x] I have added applicable tests, and not introduced any failures
