### PR TITLE
Stage partitioner changes

### DIFF
--- a/simulant.files
+++ b/simulant.files
@@ -48,6 +48,7 @@ samples/q2bsp_sample.cpp
 samples/sample.cpp
 samples/selection_sample.cpp
 samples/viewport_sample.cpp
+simulant/partitioner.cpp
 simulant/utils/string.cpp
 simulant/utils/string.h
 tests/CMakeLists.txt

--- a/simulant.files
+++ b/simulant.files
@@ -66,6 +66,7 @@ tests/test_frustum.h
 tests/test_material.h
 tests/test_material_script.h
 tests/test_mesh.h
+tests/test_partitioner.h
 tests/test_shader.h
 tests/test_sound.h
 tests/test_utils.h

--- a/simulant/math/aabb.cpp
+++ b/simulant/math/aabb.cpp
@@ -6,28 +6,29 @@ namespace smlt {
 AABB::AABB(const Vec3 &min, const Vec3 &max) {
     set_min(min);
     set_max(max);
-    rebuild_corners();
+
+    corners_dirty_ = true;
 }
 
 AABB::AABB(const Vec3 &centre, float width) {
     set_min(centre - Vec3(width * 0.5, width * 0.5, width * 0.5));
     set_max(centre + Vec3(width * 0.5, width * 0.5, width * 0.5));
 
-    rebuild_corners();
+    corners_dirty_ = true;
 }
 
 AABB::AABB(const Vec3 &centre, float xsize, float ysize, float zsize) {
     set_min(centre - Vec3(xsize * 0.5, ysize * 0.5, zsize * 0.5));
     set_max(centre + Vec3(xsize * 0.5, ysize * 0.5, zsize * 0.5));
 
-    rebuild_corners();
+    corners_dirty_ = true;
 }
 
 AABB::AABB(const Vec3 *vertices, const std::size_t count) {
     if(count == 0) {
         set_min(Vec3());
         set_max(Vec3());
-        rebuild_corners();
+        corners_dirty_ = true;
         return;
     }
 
@@ -51,8 +52,7 @@ AABB::AABB(const Vec3 *vertices, const std::size_t count) {
 
     set_min(Vec3(minx, miny, minz));
     set_max(Vec3(maxx, maxy, maxz));
-
-    rebuild_corners();
+    corners_dirty_ = true;
 }
 
 }

--- a/simulant/math/aabb.h
+++ b/simulant/math/aabb.h
@@ -13,9 +13,10 @@ class AABB {
     Vec3 min_;
     Vec3 max_;
 
-    std::array<Vec3, 8> corners_;
+    mutable std::array<Vec3, 8> corners_;
+    mutable bool corners_dirty_ = true;
 
-    void rebuild_corners() {
+    void rebuild_corners() const {
         corners_[0] = Vec3(min_.x, min_.y, min_.z);
         corners_[1] = Vec3(max_.x, min_.y, min_.z);
         corners_[2] = Vec3(max_.x, min_.y, max_.z);
@@ -25,34 +26,36 @@ class AABB {
         corners_[5] = Vec3(max_.x, max_.y, min_.z);
         corners_[6] = Vec3(max_.x, max_.y, max_.z);
         corners_[7] = Vec3(min_.x, max_.y, max_.z);
+
+        corners_dirty_ = false;
     }
 
 public:
     void set_min(const Vec3& min) {
         if(min_ != min) {
             min_ = min;
-            rebuild_corners();
+            corners_dirty_ = true;
         }
     }
 
     void set_min_x(float x) {
         if(x != min_.x) {
             min_.x = x;
-            rebuild_corners();
+            corners_dirty_ = true;
         }
     }
 
     void set_min_y(float y) {
         if(y != min_.y) {
             min_.y = y;
-            rebuild_corners();
+            corners_dirty_ = true;
         }
     }
 
     void set_min_z(float z) {
         if(z != min_.z) {
             min_.z = z;
-            rebuild_corners();
+            corners_dirty_ = true;
         }
     }
 
@@ -60,28 +63,28 @@ public:
     void set_max_x(float x) {
         if(x != max_.x) {
             max_.x = x;
-            rebuild_corners();
+            corners_dirty_ = true;
         }
     }
 
     void set_max_y(float y) {
         if(y != max_.y) {
             max_.y = y;
-            rebuild_corners();
+            corners_dirty_ = true;
         }
     }
 
     void set_max_z(float z) {
         if(z != max_.z) {
             max_.z = z;
-            rebuild_corners();
+            corners_dirty_ = true;
         }
     }
 
     void set_max(const Vec3& max) {
         if(max_ != max) {
             max_ = max;
-            rebuild_corners();
+            corners_dirty_ = true;
         }
     }
 
@@ -173,7 +176,12 @@ public:
         return false;
     }
 
+    /* NOTE: The corners are recalculated when called, so don't hold onto a reference for long */
     const std::array<Vec3, 8>& corners() const {
+        if(corners_dirty_) {
+            rebuild_corners();
+        }
+
         return corners_;
     }
 };

--- a/simulant/partitioner.cpp
+++ b/simulant/partitioner.cpp
@@ -5,6 +5,7 @@ namespace smlt {
 void Partitioner::add_particle_system(ParticleSystemID ps) {
     StagedWrite write;
     write.operation = WRITE_OPERATION_ADD;
+    write.stage_node_type = STAGE_NODE_TYPE_PARTICLE_SYSTEM;
     write.particle_system_id = ps;
     stage_write(write);
 }
@@ -12,6 +13,7 @@ void Partitioner::add_particle_system(ParticleSystemID ps) {
 void Partitioner::remove_particle_system(ParticleSystemID ps) {
     StagedWrite write;
     write.operation = WRITE_OPERATION_REMOVE;
+    write.stage_node_type = STAGE_NODE_TYPE_PARTICLE_SYSTEM;
     write.particle_system_id = ps;
     stage_write(write);
 }
@@ -19,6 +21,7 @@ void Partitioner::remove_particle_system(ParticleSystemID ps) {
 void Partitioner::add_geom(GeomID geom_id) {
     StagedWrite write;
     write.operation = WRITE_OPERATION_ADD;
+    write.stage_node_type = STAGE_NODE_TYPE_GEOM;
     write.geom_id = geom_id;
     stage_write(write);
 }
@@ -26,6 +29,7 @@ void Partitioner::add_geom(GeomID geom_id) {
 void Partitioner::remove_geom(GeomID geom_id) {
     StagedWrite write;
     write.operation = WRITE_OPERATION_REMOVE;
+    write.stage_node_type = STAGE_NODE_TYPE_GEOM;
     write.geom_id = geom_id;
     stage_write(write);
 }
@@ -33,6 +37,7 @@ void Partitioner::remove_geom(GeomID geom_id) {
 void Partitioner::add_actor(ActorID obj) {
     StagedWrite write;
     write.operation = WRITE_OPERATION_ADD;
+    write.stage_node_type = STAGE_NODE_TYPE_ACTOR;
     write.actor_id = obj;
     stage_write(write);
 }
@@ -40,6 +45,7 @@ void Partitioner::add_actor(ActorID obj) {
 void Partitioner::remove_actor(ActorID obj) {
     StagedWrite write;
     write.operation = WRITE_OPERATION_REMOVE;
+    write.stage_node_type = STAGE_NODE_TYPE_ACTOR;
     write.actor_id = obj;
     stage_write(write);
 }
@@ -47,6 +53,7 @@ void Partitioner::remove_actor(ActorID obj) {
 void Partitioner::add_light(LightID obj) {
     StagedWrite write;
     write.operation = WRITE_OPERATION_ADD;
+    write.stage_node_type = STAGE_NODE_TYPE_LIGHT;
     write.light_id = obj;
     stage_write(write);
 }
@@ -54,19 +61,55 @@ void Partitioner::add_light(LightID obj) {
 void Partitioner::remove_light(LightID obj) {
     StagedWrite write;
     write.operation = WRITE_OPERATION_REMOVE;
+    write.stage_node_type = STAGE_NODE_TYPE_LIGHT;
     write.light_id = obj;
     stage_write(write);
 }
 
 void Partitioner::_apply_writes() {
-    for(auto& write: staged_writes_) {
+    std::unordered_set<ActorID> seen_actors;
+    std::unordered_set<LightID> seen_lights;
+    std::unordered_set<GeomID> seen_geoms;
+    std::unordered_set<ParticleSystemID> seen_particle_systems;
+
+    /* Iterate the staged writes in most-recent-first order, so we
+     * only apply the last write for each element */
+    while(!staged_writes_.empty()) {
+        auto write = staged_writes_.top();
+        staged_writes_.pop();
+
+        if(write.stage_node_type == STAGE_NODE_TYPE_ACTOR) {
+            if(seen_actors.count(write.actor_id)) {
+                continue;
+            } else {
+                seen_actors.insert(write.actor_id);
+            }
+        } else if(write.stage_node_type == STAGE_NODE_TYPE_GEOM) {
+            if(seen_geoms.count(write.geom_id)) {
+                continue;
+            } else {
+                seen_geoms.insert(write.geom_id);
+            }
+        } else if(write.stage_node_type == STAGE_NODE_TYPE_LIGHT) {
+            if(seen_lights.count(write.light_id)) {
+                continue;
+            } else {
+                seen_lights.insert(write.light_id);
+            }
+        } else if(write.stage_node_type == STAGE_NODE_TYPE_PARTICLE_SYSTEM) {
+            if(seen_particle_systems.count(write.particle_system_id)) {
+                continue;
+            } else {
+                seen_particle_systems.insert(write.particle_system_id);
+            }
+        }
+
         apply_staged_write(write);
     }
-    staged_writes_.clear();
 }
 
 void Partitioner::stage_write(const StagedWrite &op) {
-    staged_writes_.push_back(op);
+    staged_writes_.push(op);
 }
 
 }

--- a/simulant/partitioner.cpp
+++ b/simulant/partitioner.cpp
@@ -10,6 +10,14 @@ void Partitioner::add_particle_system(ParticleSystemID ps) {
     stage_write(write);
 }
 
+void Partitioner::update_particle_system(ParticleSystemID ps, const AABB &bounds) {
+    StagedWrite write;
+    write.operation = WRITE_OPERATION_UPDATE;
+    write.new_bounds = bounds;
+    write.particle_system_id = ps;
+    stage_write(write);
+}
+
 void Partitioner::remove_particle_system(ParticleSystemID ps) {
     StagedWrite write;
     write.operation = WRITE_OPERATION_REMOVE;
@@ -42,6 +50,14 @@ void Partitioner::add_actor(ActorID obj) {
     stage_write(write);
 }
 
+void Partitioner::update_actor(ActorID actor_id, const AABB &bounds) {
+    StagedWrite write;
+    write.operation = WRITE_OPERATION_UPDATE;
+    write.new_bounds = bounds;
+    write.actor_id = actor_id;
+    stage_write(write);
+}
+
 void Partitioner::remove_actor(ActorID obj) {
     StagedWrite write;
     write.operation = WRITE_OPERATION_REMOVE;
@@ -55,6 +71,14 @@ void Partitioner::add_light(LightID obj) {
     write.operation = WRITE_OPERATION_ADD;
     write.stage_node_type = STAGE_NODE_TYPE_LIGHT;
     write.light_id = obj;
+    stage_write(write);
+}
+
+void Partitioner::update_light(LightID light_id, const AABB &bounds) {
+    StagedWrite write;
+    write.operation = WRITE_OPERATION_UPDATE;
+    write.new_bounds = bounds;
+    write.light_id = light_id;
     stage_write(write);
 }
 

--- a/simulant/partitioner.cpp
+++ b/simulant/partitioner.cpp
@@ -1,0 +1,72 @@
+#include "partitioner.h"
+
+namespace smlt {
+
+void Partitioner::add_particle_system(ParticleSystemID ps) {
+    StagedWrite write;
+    write.operation = WRITE_OPERATION_ADD;
+    write.particle_system_id = ps;
+    stage_write(write);
+}
+
+void Partitioner::remove_particle_system(ParticleSystemID ps) {
+    StagedWrite write;
+    write.operation = WRITE_OPERATION_REMOVE;
+    write.particle_system_id = ps;
+    stage_write(write);
+}
+
+void Partitioner::add_geom(GeomID geom_id) {
+    StagedWrite write;
+    write.operation = WRITE_OPERATION_ADD;
+    write.geom_id = geom_id;
+    stage_write(write);
+}
+
+void Partitioner::remove_geom(GeomID geom_id) {
+    StagedWrite write;
+    write.operation = WRITE_OPERATION_REMOVE;
+    write.geom_id = geom_id;
+    stage_write(write);
+}
+
+void Partitioner::add_actor(ActorID obj) {
+    StagedWrite write;
+    write.operation = WRITE_OPERATION_ADD;
+    write.actor_id = obj;
+    stage_write(write);
+}
+
+void Partitioner::remove_actor(ActorID obj) {
+    StagedWrite write;
+    write.operation = WRITE_OPERATION_REMOVE;
+    write.actor_id = obj;
+    stage_write(write);
+}
+
+void Partitioner::add_light(LightID obj) {
+    StagedWrite write;
+    write.operation = WRITE_OPERATION_ADD;
+    write.light_id = obj;
+    stage_write(write);
+}
+
+void Partitioner::remove_light(LightID obj) {
+    StagedWrite write;
+    write.operation = WRITE_OPERATION_REMOVE;
+    write.light_id = obj;
+    stage_write(write);
+}
+
+void Partitioner::_apply_writes() {
+    for(auto& write: staged_writes_) {
+        apply_staged_write(write);
+    }
+    staged_writes_.clear();
+}
+
+void Partitioner::stage_write(const StagedWrite &op) {
+    staged_writes_.push_back(op);
+}
+
+}

--- a/simulant/partitioner.cpp
+++ b/simulant/partitioner.cpp
@@ -13,6 +13,7 @@ void Partitioner::add_particle_system(ParticleSystemID ps) {
 void Partitioner::update_particle_system(ParticleSystemID ps, const AABB &bounds) {
     StagedWrite write;
     write.operation = WRITE_OPERATION_UPDATE;
+    write.stage_node_type = STAGE_NODE_TYPE_PARTICLE_SYSTEM;
     write.new_bounds = bounds;
     write.particle_system_id = ps;
     stage_write(write);
@@ -53,6 +54,7 @@ void Partitioner::add_actor(ActorID obj) {
 void Partitioner::update_actor(ActorID actor_id, const AABB &bounds) {
     StagedWrite write;
     write.operation = WRITE_OPERATION_UPDATE;
+    write.stage_node_type = STAGE_NODE_TYPE_ACTOR;
     write.new_bounds = bounds;
     write.actor_id = actor_id;
     stage_write(write);
@@ -77,6 +79,7 @@ void Partitioner::add_light(LightID obj) {
 void Partitioner::update_light(LightID light_id, const AABB &bounds) {
     StagedWrite write;
     write.operation = WRITE_OPERATION_UPDATE;
+    write.stage_node_type = STAGE_NODE_TYPE_LIGHT;
     write.new_bounds = bounds;
     write.light_id = light_id;
     stage_write(write);
@@ -91,43 +94,59 @@ void Partitioner::remove_light(LightID obj) {
 }
 
 void Partitioner::_apply_writes() {
-    std::unordered_set<ActorID> seen_actors;
-    std::unordered_set<LightID> seen_lights;
-    std::unordered_set<GeomID> seen_geoms;
-    std::unordered_set<ParticleSystemID> seen_particle_systems;
+    std::unordered_map<ActorID, std::set<WriteOperation>> seen_actors;
+    std::unordered_map<LightID, std::set<WriteOperation>> seen_lights;
+    std::unordered_map<GeomID, std::set<WriteOperation>> seen_geoms;
+    std::unordered_map<ParticleSystemID, std::set<WriteOperation>> seen_particle_systems;
 
-    /* Iterate the staged writes in most-recent-first order, so we
-     * only apply the last write for each element */
+    std::stack<StagedWrite> filtered;
+
+    /* Filter the list of operations so only the last operation of each
+     * type for each entity is applied. It's a stack so we iterate in most-recent-first
+     * and then push onto another stack (so the newest is at the bottom) then we iterate
+     * the filtered stack so they apply in the right order */
     while(!staged_writes_.empty()) {
         auto write = staged_writes_.top();
         staged_writes_.pop();
 
         if(write.stage_node_type == STAGE_NODE_TYPE_ACTOR) {
-            if(seen_actors.count(write.actor_id)) {
+            if(seen_actors.count(write.actor_id) && seen_actors.at(write.actor_id).count(write.operation)) {
+                // We've already seen this operation for this actor
                 continue;
             } else {
-                seen_actors.insert(write.actor_id);
-            }
-        } else if(write.stage_node_type == STAGE_NODE_TYPE_GEOM) {
-            if(seen_geoms.count(write.geom_id)) {
-                continue;
-            } else {
-                seen_geoms.insert(write.geom_id);
+                seen_actors[write.actor_id].insert(write.operation);
+                filtered.push(write);
             }
         } else if(write.stage_node_type == STAGE_NODE_TYPE_LIGHT) {
-            if(seen_lights.count(write.light_id)) {
+            if(seen_lights.count(write.light_id) && seen_lights.at(write.light_id).count(write.operation)) {
+                // We've already seen this operation for this light
                 continue;
             } else {
-                seen_lights.insert(write.light_id);
+                seen_lights[write.light_id].insert(write.operation);
+                filtered.push(write);
+            }
+        } else if(write.stage_node_type == STAGE_NODE_TYPE_GEOM) {
+            if(seen_geoms.count(write.geom_id) && seen_geoms.at(write.geom_id).count(write.operation)) {
+                // We've already seen this operation for this geom
+                continue;
+            } else {
+                seen_geoms[write.geom_id].insert(write.operation);
+                filtered.push(write);
             }
         } else if(write.stage_node_type == STAGE_NODE_TYPE_PARTICLE_SYSTEM) {
-            if(seen_particle_systems.count(write.particle_system_id)) {
+            if(seen_particle_systems.count(write.particle_system_id) && seen_particle_systems.at(write.particle_system_id).count(write.operation)) {
+                // We've already seen this operation for this particle system
                 continue;
             } else {
-                seen_particle_systems.insert(write.particle_system_id);
+                seen_particle_systems[write.particle_system_id].insert(write.operation);
+                filtered.push(write);
             }
         }
+    }
 
+    while(!filtered.empty()) {
+        auto write = filtered.top();
+        filtered.pop();
         apply_staged_write(write);
     }
 }

--- a/simulant/partitioner.h
+++ b/simulant/partitioner.h
@@ -81,6 +81,7 @@ struct StagedWrite {
     AABB new_bounds;
 };
 
+
 class Partitioner:
     public Managed<Partitioner> {
 
@@ -132,7 +133,6 @@ protected:
 
 private:
     Stage* stage_;
-
     std::stack<StagedWrite> staged_writes_;
 };
 

--- a/simulant/partitioner.h
+++ b/simulant/partitioner.h
@@ -77,6 +77,8 @@ struct StagedWrite {
     ActorID actor_id;
     LightID light_id;
     ParticleSystemID particle_system_id;
+
+    AABB new_bounds;
 };
 
 class Partitioner:
@@ -86,17 +88,20 @@ public:
     Partitioner(Stage* ss):
         stage_(ss) {}
 
-    void add_particle_system(ParticleSystemID ps);
-    void remove_particle_system(ParticleSystemID ps);
+    void add_particle_system(ParticleSystemID particle_system_id);
+    void update_particle_system(ParticleSystemID particle_system_id, const AABB& bounds);
+    void remove_particle_system(ParticleSystemID particle_system_id);
 
     void add_geom(GeomID geom_id);
     void remove_geom(GeomID geom_id);
 
-    void add_actor(ActorID obj);
-    void remove_actor(ActorID obj);
+    void add_actor(ActorID actor_id);
+    void update_actor(ActorID actor_id, const AABB& bounds);
+    void remove_actor(ActorID actor_id);
 
-    void add_light(LightID obj);
-    void remove_light(LightID obj);
+    void add_light(LightID light_id);
+    void update_light(LightID light_id, const AABB& bounds);
+    void remove_light(LightID light_id);
 
     void _apply_writes();
 

--- a/simulant/partitioner.h
+++ b/simulant/partitioner.h
@@ -19,6 +19,7 @@
 #ifndef PARTITIONER_H
 #define PARTITIONER_H
 
+#include <stack>
 #include <memory>
 #include <set>
 #include <vector>
@@ -61,8 +62,16 @@ enum WriteOperation {
     WRITE_OPERATION_REMOVE
 };
 
+enum StageNodeType {
+    STAGE_NODE_TYPE_ACTOR,
+    STAGE_NODE_TYPE_LIGHT,
+    STAGE_NODE_TYPE_GEOM,
+    STAGE_NODE_TYPE_PARTICLE_SYSTEM
+};
+
 struct StagedWrite {
     WriteOperation operation;
+    StageNodeType stage_node_type;
 
     GeomID geom_id;
     ActorID actor_id;
@@ -119,7 +128,7 @@ protected:
 private:
     Stage* stage_;
 
-    std::list<StagedWrite> staged_writes_;
+    std::stack<StagedWrite> staged_writes_;
 };
 
 }

--- a/simulant/partitioner.h
+++ b/simulant/partitioner.h
@@ -55,6 +55,21 @@ struct StaticChunkChangeEvent {
 };
 
 
+enum WriteOperation {
+    WRITE_OPERATION_ADD,
+    WRITE_OPERATION_UPDATE,
+    WRITE_OPERATION_REMOVE
+};
+
+struct StagedWrite {
+    WriteOperation operation;
+
+    GeomID geom_id;
+    ActorID actor_id;
+    LightID light_id;
+    ParticleSystemID particle_system_id;
+};
+
 class Partitioner:
     public Managed<Partitioner> {
 
@@ -62,17 +77,19 @@ public:
     Partitioner(Stage* ss):
         stage_(ss) {}
 
-    virtual void add_particle_system(ParticleSystemID ps) = 0;
-    virtual void remove_particle_system(ParticleSystemID ps) = 0;
+    void add_particle_system(ParticleSystemID ps);
+    void remove_particle_system(ParticleSystemID ps);
 
-    virtual void add_geom(GeomID geom_id) = 0;
-    virtual void remove_geom(GeomID geom_id) = 0;
+    void add_geom(GeomID geom_id);
+    void remove_geom(GeomID geom_id);
 
-    virtual void add_actor(ActorID obj) = 0;
-    virtual void remove_actor(ActorID obj) = 0;
+    void add_actor(ActorID obj);
+    void remove_actor(ActorID obj);
 
-    virtual void add_light(LightID obj) = 0;
-    virtual void remove_light(LightID obj) = 0;
+    void add_light(LightID obj);
+    void remove_light(LightID obj);
+
+    void _apply_writes();
 
     virtual std::vector<LightID> lights_visible_from(CameraID camera_id) = 0;
     virtual std::vector<std::shared_ptr<Renderable>> geometry_visible_from(CameraID camera_id) = 0;
@@ -94,8 +111,15 @@ protected:
     StaticChunkChanged signal_static_chunk_changed_;
 
     Stage* get_stage() const { return stage_; }
+
+    void stage_write(const StagedWrite& op);
+
+    virtual void apply_staged_write(const StagedWrite& write) = 0;
+
 private:
     Stage* stage_;
+
+    std::list<StagedWrite> staged_writes_;
 };
 
 }

--- a/simulant/partitioners/null_partitioner.cpp
+++ b/simulant/partitioners/null_partitioner.cpp
@@ -42,6 +42,32 @@ std::vector<LightID> NullPartitioner::lights_visible_from(CameraID camera_id) {
     return result;
 }
 
+void NullPartitioner::apply_staged_write(const StagedWrite &write) {
+    if(write.operation == WRITE_OPERATION_ADD) {
+        if(write.actor_id) {
+            all_actors_.insert(write.actor_id);
+        } else if(write.geom_id) {
+            all_geoms_.insert(write.geom_id);
+        } else if(write.light_id) {
+            all_lights_.insert(write.light_id);
+        } else if(write.particle_system_id) {
+            all_particle_systems_.insert(write.particle_system_id);
+        }
+    } else if(write.operation == WRITE_OPERATION_REMOVE) {
+        if(write.actor_id) {
+            all_actors_.erase(write.actor_id);
+        } else if(write.geom_id) {
+            all_geoms_.erase(write.geom_id);
+        } else if(write.light_id) {
+            all_lights_.erase(write.light_id);
+        } else if(write.particle_system_id) {
+            all_particle_systems_.erase(write.particle_system_id);
+        }
+    } else if(write.operation == WRITE_OPERATION_UPDATE) {
+        // Do nothing!
+    }
+}
+
 std::vector<RenderablePtr> NullPartitioner::geometry_visible_from(CameraID camera_id) {
     std::vector<RenderablePtr> result;
 

--- a/simulant/partitioners/null_partitioner.h
+++ b/simulant/partitioners/null_partitioner.h
@@ -30,42 +30,13 @@ public:
     NullPartitioner(Stage* ss):
         Partitioner(ss) {}
 
-    void add_actor(ActorID obj) {
-        all_actors_.insert(obj);
-    }
-
-    void remove_actor(ActorID obj) {
-        all_actors_.erase(obj);
-    }
-
-    void add_geom(GeomID geom_id) {
-        all_geoms_.insert(geom_id);
-    }
-
-    void remove_geom(GeomID geom_id) {
-        all_geoms_.erase(geom_id);
-    }
-
-    void add_light(LightID obj) {
-        all_lights_.insert(obj);
-    }
-
-    void remove_light(LightID obj) {
-        all_lights_.erase(obj);
-    }
-
-    void add_particle_system(ParticleSystemID ps) {
-        all_particle_systems_.insert(ps);
-    }
-
-    void remove_particle_system(ParticleSystemID ps) {
-        all_particle_systems_.erase(ps);
-    }
-
     std::vector<LightID> lights_visible_from(CameraID camera_id);
     std::vector<std::shared_ptr<Renderable>> geometry_visible_from(CameraID camera_id);
 
 private:
+    void apply_staged_write(const StagedWrite& write);
+
+
     std::set<ParticleSystemID> all_particle_systems_;
     std::set<ActorID> all_actors_;
     std::set<GeomID> all_geoms_;

--- a/simulant/partitioners/spatial_hash.h
+++ b/simulant/partitioners/spatial_hash.h
@@ -51,10 +51,6 @@ public:
     std::vector<LightID> lights_visible_from(CameraID camera_id);
     std::vector<RenderablePtr> geometry_visible_from(CameraID camera_id);
 
-    void _update_actor(const AABB& bounds, ActorID actor);
-    void _update_particle_system(const AABB& bounds, ParticleSystemID ps);
-    void _update_light(const AABB& bounds, LightID light);
-
 private:
     void stage_add_actor(ActorID obj);
     void stage_remove_actor(ActorID obj);
@@ -67,6 +63,10 @@ private:
 
     void stage_add_particle_system(ParticleSystemID ps);
     void stage_remove_particle_system(ParticleSystemID ps);
+
+    void _update_actor(const AABB& bounds, ActorID actor);
+    void _update_particle_system(const AABB& bounds, ParticleSystemID ps);
+    void _update_light(const AABB& bounds, LightID light);
 
     void apply_staged_write(const StagedWrite& write);
 
@@ -81,10 +81,6 @@ private:
     std::unordered_set<LightID> directional_lights_;
 
     shared_mutex lock_;
-
-    std::unordered_map<ActorID, sig::connection> actor_updates_;
-    std::unordered_map<ParticleSystemID, sig::connection> particle_system_updates_;
-    std::unordered_map<LightID, sig::connection> light_updates_;
 };
 
 }

--- a/simulant/partitioners/spatial_hash.h
+++ b/simulant/partitioners/spatial_hash.h
@@ -48,18 +48,6 @@ public:
     SpatialHashPartitioner(Stage* ss);
     ~SpatialHashPartitioner();
 
-    void add_actor(ActorID obj);
-    void remove_actor(ActorID obj);
-
-    void add_geom(GeomID geom_id);
-    void remove_geom(GeomID geom_id);
-
-    void add_light(LightID obj);
-    void remove_light(LightID obj);
-
-    void add_particle_system(ParticleSystemID ps);
-    void remove_particle_system(ParticleSystemID ps);
-
     std::vector<LightID> lights_visible_from(CameraID camera_id);
     std::vector<RenderablePtr> geometry_visible_from(CameraID camera_id);
 
@@ -68,6 +56,20 @@ public:
     void _update_light(const AABB& bounds, LightID light);
 
 private:
+    void stage_add_actor(ActorID obj);
+    void stage_remove_actor(ActorID obj);
+
+    void stage_add_geom(GeomID geom_id);
+    void stage_remove_geom(GeomID geom_id);
+
+    void stage_add_light(LightID obj);
+    void stage_remove_light(LightID obj);
+
+    void stage_add_particle_system(ParticleSystemID ps);
+    void stage_remove_particle_system(ParticleSystemID ps);
+
+    void apply_staged_write(const StagedWrite& write);
+
     SpatialHash* hash_ = nullptr;
 
     typedef std::shared_ptr<PartitionerEntry> PartitionerEntryPtr;

--- a/simulant/render_sequence.cpp
+++ b/simulant/render_sequence.cpp
@@ -243,6 +243,9 @@ void RenderSequence::run_pipeline(Pipeline::ptr pipeline_stage, int &actors_rend
     // Trigger a signal to indicate the stage is about to be rendered
     stage->signal_stage_pre_render()(camera_id, viewport);
 
+    // Apply any outstanding writes to the partitioner
+    stage->partitioner->_apply_writes();
+
     auto light_ids = stage->partitioner->lights_visible_from(camera_id);
     auto lights_visible = map<decltype(light_ids), std::vector<LightPtr>>(
         light_ids, [&](const LightID& light_id) -> LightPtr { return stage->light(light_id); }

--- a/tests/test_partitioner.h
+++ b/tests/test_partitioner.h
@@ -1,0 +1,153 @@
+#pragma once
+
+#include <functional>
+#include "kaztest/kaztest.h"
+#include "global.h"
+#include "../../simulant/partitioner.h"
+
+
+namespace {
+
+using namespace smlt;
+
+class MockPartitioner : public Partitioner {
+public:
+    MockPartitioner(StagePtr stage, std::function<void (const StagedWrite&)> cb):
+        Partitioner(stage),
+        cb_(cb) {}
+
+    void apply_staged_write(const StagedWrite& write) {
+        cb_(write);
+    }
+
+    std::vector<LightID> lights_visible_from(CameraID camera_id) { return std::vector<LightID>(); }
+    std::vector<std::shared_ptr<Renderable>> geometry_visible_from(CameraID camera_id) { return std::vector<std::shared_ptr<Renderable>>(); }
+
+private:
+    std::function<void (const StagedWrite&)> cb_;
+};
+
+
+class PartitionerTests : public SimulantTestCase {
+public:
+    void test_add_actor_stages_write() {
+        auto test = [=](const StagedWrite& write) {
+            assert_equal(write.stage_node_type, STAGE_NODE_TYPE_ACTOR);
+            assert_equal(write.operation, WRITE_OPERATION_ADD);
+            assert_true(write.actor_id);
+            assert_false(write.light_id);
+            assert_false(write.particle_system_id);
+            assert_false(write.geom_id);
+        };
+
+        StagePtr stage = window->new_stage().fetch();
+        ActorID actor = stage->new_actor();
+
+        MockPartitioner partitioner(stage, test);
+        partitioner.add_actor(actor);
+        partitioner._apply_writes();
+
+        window->delete_stage(stage->id());
+    }
+
+    void test_remove_actor_stages_write() {
+        auto test = [=](const StagedWrite& write) {
+            assert_equal(write.stage_node_type, STAGE_NODE_TYPE_ACTOR);
+            assert_equal(write.operation, WRITE_OPERATION_REMOVE);
+            assert_true(write.actor_id);
+            assert_false(write.light_id);
+            assert_false(write.particle_system_id);
+            assert_false(write.geom_id);
+        };
+
+        StagePtr stage = window->new_stage().fetch();
+        ActorID actor = stage->new_actor();
+
+        MockPartitioner partitioner(stage, test);
+        partitioner.remove_actor(actor);
+        partitioner._apply_writes();
+
+        window->delete_stage(stage->id());
+    }
+
+    void test_add_light_stages_write() {
+        auto test = [=](const StagedWrite& write) {
+            assert_equal(write.stage_node_type, STAGE_NODE_TYPE_LIGHT);
+            assert_equal(write.operation, WRITE_OPERATION_ADD);
+            assert_false(write.actor_id);
+            assert_true(write.light_id);
+            assert_false(write.particle_system_id);
+            assert_false(write.geom_id);
+        };
+
+        StagePtr stage = window->new_stage().fetch();
+        LightID light = stage->new_light_as_point();
+
+        MockPartitioner partitioner(stage, test);
+        partitioner.add_light(light);
+        partitioner._apply_writes();
+
+        window->delete_stage(stage->id());
+    }
+
+    void test_remove_light_stages_write() {
+        auto test = [=](const StagedWrite& write) {
+            assert_equal(write.stage_node_type, STAGE_NODE_TYPE_LIGHT);
+            assert_equal(write.operation, WRITE_OPERATION_REMOVE);
+            assert_false(write.actor_id);
+            assert_true(write.light_id);
+            assert_false(write.particle_system_id);
+            assert_false(write.geom_id);
+        };
+
+        StagePtr stage = window->new_stage().fetch();
+        LightID light = stage->new_light_as_point();
+
+        MockPartitioner partitioner(stage, test);
+        partitioner.remove_light(light);
+        partitioner._apply_writes();
+
+        window->delete_stage(stage->id());
+    }
+
+    void test_add_particle_system_stages_write() {
+        auto test = [=](const StagedWrite& write) {
+            assert_equal(write.stage_node_type, STAGE_NODE_TYPE_PARTICLE_SYSTEM);
+            assert_equal(write.operation, WRITE_OPERATION_ADD);
+            assert_false(write.actor_id);
+            assert_false(write.light_id);
+            assert_true(write.particle_system_id);
+            assert_false(write.geom_id);
+        };
+
+        StagePtr stage = window->new_stage().fetch();
+        ParticleSystemID ps = stage->new_particle_system();
+
+        MockPartitioner partitioner(stage, test);
+        partitioner.add_particle_system(ps);
+        partitioner._apply_writes();
+
+        window->delete_stage(stage->id());
+    }
+
+    void test_remove_particle_system_stages_write() {
+        auto test = [=](const StagedWrite& write) {
+            assert_equal(write.stage_node_type, STAGE_NODE_TYPE_PARTICLE_SYSTEM);
+            assert_equal(write.operation, WRITE_OPERATION_REMOVE);
+            assert_false(write.actor_id);
+            assert_false(write.light_id);
+            assert_true(write.particle_system_id);
+            assert_false(write.geom_id);
+        };
+
+        StagePtr stage = window->new_stage().fetch();
+        ParticleSystemID ps = stage->new_particle_system();
+
+        MockPartitioner partitioner(stage, test);
+        partitioner.remove_particle_system(ps);
+        partitioner._apply_writes();
+        window->delete_stage(stage->id());
+    }
+};
+
+}


### PR DESCRIPTION
Fixes #46

# Summary of Changes Introduced

 - Fixes a performance issue where the partitioner could be needlessly updated several times per frame for one object

# PR Checklist

- [ ] I have documented any changes to the code in the documentation folder
- [x] I agree that the changes introduced in this PR are dual-licensed under the LGPL
- [x] I have added applicable tests, and not introduced any failures
