### PR TITLE
Fix stage node movement

### DIFF
--- a/simulant/nodes/camera.cpp
+++ b/simulant/nodes/camera.cpp
@@ -47,11 +47,23 @@ void Camera::on_parent_set(TreeNode* oldp, TreeNode* newp) {
     update_frustum();
 }
 
+void Camera::update_position_from_parent(bool _recalc_bounds) {
+    StageNode::update_position_from_parent(_recalc_bounds);
+    transform_ = absolute_transformation();
+    update_frustum();
+}
+
+void Camera::update_rotation_from_parent() {
+    StageNode::update_rotation_from_parent();
+    transform_ = absolute_transformation();
+    update_frustum();
+}
+
 void Camera::update_frustum() {
     //Recalculate the view matrix
     view_matrix_ = transform_.inversed();
 
-    Mat4 mvp = projection_matrix() * view_matrix();
+    Mat4 mvp = projection_matrix_ * view_matrix_;
 
     frustum_.build(&mvp); //Update the frustum for this camera
 }

--- a/simulant/nodes/camera.h
+++ b/simulant/nodes/camera.h
@@ -63,6 +63,9 @@ private:
     void on_rotation_set(const Quaternion& oldr, const Quaternion& newr) override;
     void on_scaling_set(const Vec3& olds, const Vec3& news) override;
     void on_parent_set(TreeNode* oldp, TreeNode* newp) override;
+
+    void update_position_from_parent(bool _recalc_bounds);
+    void update_rotation_from_parent();
 };
 
 }

--- a/simulant/nodes/stage_node.h
+++ b/simulant/nodes/stage_node.h
@@ -86,10 +86,11 @@ protected:
     void on_scaling_set(const Vec3& olds, const Vec3& news) override;
     void on_parent_set(TreeNode* oldp, TreeNode* newp) override;
 
+    virtual void update_rotation_from_parent();
+    virtual void update_position_from_parent(bool _recalc_bounds=true);
+    virtual void update_scaling_from_parent();
 private:
-    void update_rotation_from_parent();
-    void update_position_from_parent(bool _recalc_bounds=true);
-    void update_scaling_from_parent();
+
     void recalc_bounds();
 
     Stage* stage_ = nullptr;

--- a/simulant/nodes/tree_node.cpp
+++ b/simulant/nodes/tree_node.cpp
@@ -25,6 +25,11 @@ void TreeNode::set_parent(TreeNode *node) {
         return;
     }
 
+    if(node == this) {
+        // Do nothing if we tried to set the parent node to itself
+        return;
+    }
+
     if(node) {
         node->add_child(this);
     }

--- a/tests/test_camera.h
+++ b/tests/test_camera.h
@@ -62,6 +62,24 @@ public:
         assert_close(res.z, 1, 0.000001);
     }
 
+    void test_camera_attached_to_parent_moves() {
+        auto stage = window->new_stage().fetch();
+
+        auto actor = stage->new_actor().fetch();
+        auto camera = stage->new_camera().fetch();
+
+        auto od = camera->frustum().plane(FRUSTUM_PLANE_NEAR).d;
+
+        camera->move_to(0, 0, 10.0f);
+        camera->set_parent(actor);
+
+        actor->move_to(0, 0, -10.0f);
+        assert_close(camera->absolute_position().z, 0.0f, 0.00001f);
+
+        auto d = camera->frustum().plane(FRUSTUM_PLANE_NEAR).d;
+        assert_close(d, od, 0.00001f);
+    }
+
 private:
     CameraID camera_id_;
     StageID stage_id_;

--- a/tests/test_object.h
+++ b/tests/test_object.h
@@ -183,6 +183,27 @@ public:
         assert_equal(smlt::Vec3(10, 0, 0), actor2->position());
     }
 
+    void test_move_updates_children() {
+        auto stage = stage_id_.fetch();
+
+        auto actor1 = stage->new_actor().fetch();
+        auto actor2 = stage->new_actor().fetch();
+
+        actor2->move_to(0, 0, 10.0f);
+        actor2->set_parent(actor1);
+
+        assert_equal(10.0f, actor2->absolute_position().z);
+    }
+
+    void test_set_parent_to_self_does_nothing() {
+        auto stage = stage_id_.fetch();
+        auto actor1 = stage->new_actor().fetch();
+
+        auto original_parent = actor1->parent();
+        actor1->set_parent(actor1);
+        assert_equal(original_parent, actor1->parent());
+    }
+
 private:
     smlt::CameraID camera_id_;
     smlt::StageID stage_id_;


### PR DESCRIPTION
Fixes #75 

# Summary of Changes Introduced

 - Fixes issue where the Camera's frustum wasn't updated if attached to a parent node

# PR Checklist

- [ ] I have documented any changes to the code in the documentation folder
- [x] I agree that the changes introduced in this PR are licensed under the [LGPL-3.0](https://opensource.org/licenses/LGPL-3.0)  ([Why?](../documentation/license.md))
- [x] I have added applicable tests, and not introduced any failures
