### PR TITLE
Move scene manager

### DIFF
--- a/documentation/scene.md
+++ b/documentation/scene.md
@@ -8,7 +8,7 @@ A scene is designed to be a single screen in your game. For example, you might h
 Scenes are subclasses of a class template called `Scene<T>`. To create your Scene class you must do the following:
 
  - Subclass `Scene<T>` but pass your class up as `T` (Search for the 'Curiously Recurring Template Pattern' for more info)
- - Add a pass-through constructor which takes a `Window&` reference and passes it to the parent constructor
+ - Add a pass-through constructor which takes a `Window*` and passes it to the parent constructor
  - Override the `void load()` method
 
 Here's an example:
@@ -17,7 +17,7 @@ Here's an example:
 
 class MyScene : public Scene<MyScene> {
 public:
-    MyScene(Window& window):
+    MyScene(Window* window):
         Scene<MyScene>(window) {}
 
     void load();
@@ -50,3 +50,7 @@ You can override the following methods in your Scene class:
  - late_update()
 
 `activate()` and `deactivate()` are called when you change to a different scene.
+
+
+
+

--- a/documentation/scene.md
+++ b/documentation/scene.md
@@ -30,7 +30,7 @@ You can then register the Scene in your application's `init()` method:
 
 ```
     bool init() {
-        register_scene<MyScene>("main");
+        scenes->register_scene<MyScene>("main");
         return true;
     }
 ```
@@ -51,6 +51,27 @@ You can override the following methods in your Scene class:
 
 `activate()` and `deactivate()` are called when you change to a different scene.
 
+# Scene Management
+
+`Scenes` are managed by the `SceneManager`, which is a property of `Application`. The application `SceneManager` is accessible directly from within a scene using the `scenes` property.
+
+You can make a `Scene` current by calling `SceneManager::activate(name, behaviour)`. This will do a number of things:
+
+ - If a `Scene` is already active, it will be deactivated.
+ - If the behaviour is set to `SCENE_CHANGE_BEHAVIOUR_UNLOAD` then the old `Scene` will have its `unload()` method called. 
+ - If `Scene::destroy_on_unload()` is true, then the old `Scene` will be deleted.
+ - If this is the first time that this scene name has been activated, a new `Scene` will be instantiated.
+ - If the new `Scene` hasn't been loaded, its `load()` method will be called.
+ - `Scene::activate()` will be called on the new scene
+
+You have a lot of control over this process:
+
+ - You can load a `Scene` ahead of time, before activating it. 
+ - You can prevent a `Scene` from being unloaded when deactivated.
+ - You can prevent a `Scene` from being deleted when unloaded.
+ 
+This means that you can (for example) create render pipelines that remain active even
+once the `Scene` has been deactivated, and use that to implement transitions etc.
 
 
 

--- a/samples/2d_sample.cpp
+++ b/samples/2d_sample.cpp
@@ -67,9 +67,9 @@ public:
 
 private:
     bool init() {
-        register_scene<GameScene>("main");
-        load_scene_in_background("main", true); //Do loading in a background thread, but show immediately when done
-        activate_scene("_loading"); // Show the loading screen in the meantime
+        scenes->register_scene<GameScene>("main");
+        scenes->load_scene_in_background("main", true); //Do loading in a background thread, but show immediately when done
+        scenes->activate_scene("_loading"); // Show the loading screen in the meantime
         return true;
     }
 };

--- a/samples/2d_sample.cpp
+++ b/samples/2d_sample.cpp
@@ -69,7 +69,7 @@ private:
     bool init() {
         scenes->register_scene<GameScene>("main");
         scenes->load_in_background("main", true); //Do loading in a background thread, but show immediately when done
-        scenes->activate_scene("_loading"); // Show the loading screen in the meantime
+        scenes->activate("_loading"); // Show the loading screen in the meantime
         return true;
     }
 };

--- a/samples/2d_sample.cpp
+++ b/samples/2d_sample.cpp
@@ -68,7 +68,7 @@ public:
 private:
     bool init() {
         scenes->register_scene<GameScene>("main");
-        scenes->load_scene_in_background("main", true); //Do loading in a background thread, but show immediately when done
+        scenes->load_in_background("main", true); //Do loading in a background thread, but show immediately when done
         scenes->activate_scene("_loading"); // Show the loading screen in the meantime
         return true;
     }

--- a/samples/fleets_demo.cpp
+++ b/samples/fleets_demo.cpp
@@ -79,7 +79,7 @@ private:
     bool init() {
         scenes->register_scene<GameScene>("main");
         scenes->load_in_background("main", true); //Do loading in a background thread, but show immediately when done
-        scenes->activate_scene("_loading"); // Show the loading screen in the meantime
+        scenes->activate("_loading"); // Show the loading screen in the meantime
         return true;
     }
 };

--- a/samples/fleets_demo.cpp
+++ b/samples/fleets_demo.cpp
@@ -78,7 +78,7 @@ public:
 private:
     bool init() {
         scenes->register_scene<GameScene>("main");
-        scenes->load_scene_in_background("main", true); //Do loading in a background thread, but show immediately when done
+        scenes->load_in_background("main", true); //Do loading in a background thread, but show immediately when done
         scenes->activate_scene("_loading"); // Show the loading screen in the meantime
         return true;
     }

--- a/samples/fleets_demo.cpp
+++ b/samples/fleets_demo.cpp
@@ -77,9 +77,9 @@ public:
 
 private:
     bool init() {
-        register_scene<GameScene>("main");
-        load_scene_in_background("main", true); //Do loading in a background thread, but show immediately when done
-        activate_scene("_loading"); // Show the loading screen in the meantime
+        scenes->register_scene<GameScene>("main");
+        scenes->load_scene_in_background("main", true); //Do loading in a background thread, but show immediately when done
+        scenes->activate_scene("_loading"); // Show the loading screen in the meantime
         return true;
     }
 };

--- a/samples/light_sample.cpp
+++ b/samples/light_sample.cpp
@@ -68,7 +68,7 @@ public:
 
 private:
     bool init() {
-        register_scene<GameScene>("main");
+        scenes->register_scene<GameScene>("main");
         return true;
     }
 };

--- a/samples/nehe01.cpp
+++ b/samples/nehe01.cpp
@@ -33,7 +33,7 @@ public:
     }
 
     bool init() {
-        register_scene<MainScene>("main");
+        scenes->register_scene<MainScene>("main");
         return true;
     }
 };

--- a/samples/particles.cpp
+++ b/samples/particles.cpp
@@ -42,7 +42,7 @@ public:
     }
 
     bool init() {
-        register_scene<MainScene>("main");
+        scenes->register_scene<MainScene>("main");
         return true;
     }
 };

--- a/samples/physics_demo.cpp
+++ b/samples/physics_demo.cpp
@@ -99,7 +99,7 @@ public:
 private:
     bool init() {
         scenes->register_scene<GameScene>("main");
-        scenes->load_scene_in_background("main", true); //Do loading in a background thread, but show immediately when done
+        scenes->load_in_background("main", true); //Do loading in a background thread, but show immediately when done
         scenes->activate_scene("_loading"); // Show the loading screen in the meantime
         return true;
     }

--- a/samples/physics_demo.cpp
+++ b/samples/physics_demo.cpp
@@ -98,9 +98,9 @@ public:
 
 private:
     bool init() {
-        register_scene<GameScene>("main");
-        load_scene_in_background("main", true); //Do loading in a background thread, but show immediately when done
-        activate_scene("_loading"); // Show the loading screen in the meantime
+        scenes->register_scene<GameScene>("main");
+        scenes->load_scene_in_background("main", true); //Do loading in a background thread, but show immediately when done
+        scenes->activate_scene("_loading"); // Show the loading screen in the meantime
         return true;
     }
 };

--- a/samples/physics_demo.cpp
+++ b/samples/physics_demo.cpp
@@ -100,7 +100,7 @@ private:
     bool init() {
         scenes->register_scene<GameScene>("main");
         scenes->load_in_background("main", true); //Do loading in a background thread, but show immediately when done
-        scenes->activate_scene("_loading"); // Show the loading screen in the meantime
+        scenes->activate("_loading"); // Show the loading screen in the meantime
         return true;
     }
 };

--- a/samples/q2bsp_sample.cpp
+++ b/samples/q2bsp_sample.cpp
@@ -58,7 +58,7 @@ public:
 private:
     bool init() {
         scenes->register_scene<GameScene>("main");
-        scenes->load_scene_in_background("main", true); //Do loading in a background thread, but show immediately when done
+        scenes->load_in_background("main", true); //Do loading in a background thread, but show immediately when done
         scenes->activate_scene("_loading"); // Show the loading screen in the meantime
         return true;
     }

--- a/samples/q2bsp_sample.cpp
+++ b/samples/q2bsp_sample.cpp
@@ -57,9 +57,9 @@ public:
 
 private:
     bool init() {
-        register_scene<GameScene>("main");
-        load_scene_in_background("main", true); //Do loading in a background thread, but show immediately when done
-        activate_scene("_loading"); // Show the loading screen in the meantime
+        scenes->register_scene<GameScene>("main");
+        scenes->load_scene_in_background("main", true); //Do loading in a background thread, but show immediately when done
+        scenes->activate_scene("_loading"); // Show the loading screen in the meantime
         return true;
     }
 };

--- a/samples/q2bsp_sample.cpp
+++ b/samples/q2bsp_sample.cpp
@@ -59,7 +59,7 @@ private:
     bool init() {
         scenes->register_scene<GameScene>("main");
         scenes->load_in_background("main", true); //Do loading in a background thread, but show immediately when done
-        scenes->activate_scene("_loading"); // Show the loading screen in the meantime
+        scenes->activate("_loading"); // Show the loading screen in the meantime
         return true;
     }
 };

--- a/samples/rtt_sample.cpp
+++ b/samples/rtt_sample.cpp
@@ -51,7 +51,7 @@ public:
 
 private:
     bool init() {
-        register_scene<GameScene>("main");
+        scenes->register_scene<GameScene>("main");
         return true;
     }
 };

--- a/samples/sample.cpp
+++ b/samples/sample.cpp
@@ -57,7 +57,7 @@ public:
 
 private:
     bool init() {
-        register_scene<GameScene>("main");
+        scenes->register_scene<GameScene>("main");
         return true;
     }
 };

--- a/samples/terrain_sample.cpp
+++ b/samples/terrain_sample.cpp
@@ -122,7 +122,7 @@ private:
     bool init() {
         scenes->register_scene<Gamescene>("main");
         scenes->load_in_background("main", true); //Do loading in a background thread, but show immediately when done
-        scenes->activate_scene("_loading"); // Show the loading scene in the meantime
+        scenes->activate("_loading"); // Show the loading scene in the meantime
         return true;
     }
 };

--- a/samples/terrain_sample.cpp
+++ b/samples/terrain_sample.cpp
@@ -121,7 +121,7 @@ public:
 private:
     bool init() {
         scenes->register_scene<Gamescene>("main");
-        scenes->load_scene_in_background("main", true); //Do loading in a background thread, but show immediately when done
+        scenes->load_in_background("main", true); //Do loading in a background thread, but show immediately when done
         scenes->activate_scene("_loading"); // Show the loading scene in the meantime
         return true;
     }

--- a/samples/terrain_sample.cpp
+++ b/samples/terrain_sample.cpp
@@ -40,7 +40,7 @@ public:
         smlt::Scene<Gamescene>(window) {}
 
     void load() {
-        auto loading = window->application->resolve_scene_as<scenes::Loading>("_loading");
+        auto loading = scenes->resolve_scene_as<scenes::Loading>("_loading");
         assert(loading);
 
         bool done = false;
@@ -120,9 +120,9 @@ public:
 
 private:
     bool init() {
-        register_scene<Gamescene>("main");
-        load_scene_in_background("main", true); //Do loading in a background thread, but show immediately when done
-        activate_scene("_loading"); // Show the loading scene in the meantime
+        scenes->register_scene<Gamescene>("main");
+        scenes->load_scene_in_background("main", true); //Do loading in a background thread, but show immediately when done
+        scenes->activate_scene("_loading"); // Show the loading scene in the meantime
         return true;
     }
 };

--- a/samples/ui_demo.cpp
+++ b/samples/ui_demo.cpp
@@ -47,7 +47,7 @@ public:
     }
 
     bool init() {
-        register_scene<MainScene>("main");
+        scenes->register_scene<MainScene>("main");
         return true;
     }
 };

--- a/samples/viewport_sample.cpp
+++ b/samples/viewport_sample.cpp
@@ -32,7 +32,7 @@ public:
         smlt::Application(config) {}
 
     bool init() {
-        register_scene<MainScene>("main");
+        scenes->register_scene<MainScene>("main");
         return true;
     }
 };

--- a/simulant/application.cpp
+++ b/simulant/application.cpp
@@ -79,7 +79,7 @@ bool Application::_call_init() {
     // Add some useful scenes by default, these can be overridden in init if the
     // user so wishes
     scenes->register_scene<scenes::Loading>("_loading");
-    scenes->load_scene("_loading");
+    scenes->load("_loading");
 
     initialized_ = init();
 

--- a/simulant/application.cpp
+++ b/simulant/application.cpp
@@ -86,7 +86,7 @@ bool Application::_call_init() {
     // If we successfully initialized, but the user didn't specify
     // a particular scene, we just hit the root route
     if(initialized_ && !scenes->active_scene()) {
-        scenes->activate_scene("main");
+        scenes->activate("main");
     }
 
     return initialized_;

--- a/simulant/application.cpp
+++ b/simulant/application.cpp
@@ -78,15 +78,15 @@ bool Application::_call_init() {
 
     // Add some useful scenes by default, these can be overridden in init if the
     // user so wishes
-    register_scene<scenes::Loading>("_loading");
-    load_scene("_loading");
+    scenes->register_scene<scenes::Loading>("_loading");
+    scenes->load_scene("_loading");
 
     initialized_ = init();
 
     // If we successfully initialized, but the user didn't specify
     // a particular scene, we just hit the root route
-    if(initialized_ && !active_scene()) {
-        activate_scene("main");
+    if(initialized_ && !scenes->active_scene()) {
+        scenes->activate_scene("main");
     }
 
     return initialized_;
@@ -110,46 +110,6 @@ int32_t Application::run() {
     window_.reset();
 
     return 0;
-}
-
-bool Application::has_scene(const std::string &route) const {
-    return scene_manager_->has_scene(route);
-}
-
-SceneBasePtr Application::resolve_scene(const std::string &route) {
-    return scene_manager_->resolve_scene(route);
-}
-
-void Application::activate_scene(const std::string &route, SceneChangeBehaviour behaviour) {
-    scene_manager_->activate_scene(route, behaviour);
-}
-
-void Application::load_scene(const std::string &route) {
-    scene_manager_->load_scene(route);
-}
-
-void Application::load_scene_in_background(const std::string &route, bool redirect_after) {
-    scene_manager_->load_scene_in_background(route);
-}
-
-void Application::unload_scene(const std::string &route) {
-    scene_manager_->unload_scene(route);
-}
-
-bool Application::is_scene_loaded(const std::string &route) const {
-    return scene_manager_->is_scene_loaded(route);
-}
-
-void Application::reset() {
-    scene_manager_->reset();
-}
-
-SceneBasePtr Application::active_scene() const {
-    return scene_manager_->active_scene();
-}
-
-void Application::_store_scene_factory(const std::string &name, std::function<SceneBasePtr (Window *)> func) {
-    scene_manager_->_store_scene_factory(name, func);
 }
 
 }

--- a/simulant/application.h
+++ b/simulant/application.h
@@ -59,8 +59,7 @@ struct AppConfig {
     std::vector<unicode> arguments;
 };
 
-class Application :
-    public SceneManagerInterface {
+class Application {
 
 public:
     Application(const AppConfig& config);
@@ -71,19 +70,9 @@ public:
 
     Property<Application, Window> window = {this, &Application::window_ };
     Property<Application, generic::DataCarrier> data = { this, &Application::data_carrier_ };
+    Property<Application, SceneManager> scenes = {this, &Application::scene_manager_};
 
     bool initialized() const { return initialized_; }
-
-    bool has_scene(const std::string& route) const override;
-    SceneBasePtr resolve_scene(const std::string& route) override;
-    void activate_scene(const std::string& route, SceneChangeBehaviour behaviour=SCENE_CHANGE_BEHAVIOUR_UNLOAD_CURRENT_SCENE) override;
-    void load_scene(const std::string& route) override;
-    void load_scene_in_background(const std::string& route, bool redirect_after=true) override;
-    void unload_scene(const std::string& route) override;
-    bool is_scene_loaded(const std::string& route) const override;
-    void reset() override;
-    SceneBasePtr active_scene() const override;
-    void _store_scene_factory(const std::string& name, std::function<SceneBasePtr (Window*)> func) override;
 
 protected:
     StagePtr stage(StageID stage=StageID());

--- a/simulant/scenes/physics_scene.h
+++ b/simulant/scenes/physics_scene.h
@@ -25,7 +25,7 @@ protected:
 
 private:
     void pre_load() override {
-        physics_.reset(new smlt::controllers::RigidBodySimulation(this->window_->time_keeper));
+        physics_.reset(new smlt::controllers::RigidBodySimulation(this->window->time_keeper));
     }
 
     void post_unload() override {

--- a/simulant/scenes/scene.h
+++ b/simulant/scenes/scene.h
@@ -50,6 +50,7 @@ namespace smlt {
 class Application;
 class Window;
 class InputManager;
+class SceneManager;
 
 class SceneLoadException : public std::runtime_error {};
 
@@ -90,6 +91,7 @@ protected:
     Property<SceneBase, Window> window = {this, &SceneBase::window_};
     Property<SceneBase, Application> app = {this, &SceneBase::app_};
     Property<SceneBase, InputManager> input = {this, &SceneBase::input_};
+    Property<SceneBase, SceneManager> scenes = {this, &SceneBase::scene_manager_};
 
     virtual void load() = 0;
     virtual void unload() {}
@@ -102,10 +104,6 @@ protected:
         AvailablePartitioner partitioner=PARTITIONER_HASH
     );
 
-    Window* window_;
-    InputManager* input_;
-    Application* app_;
-
 private:
     virtual void pre_load() {}
     virtual void post_unload() {}
@@ -115,6 +113,13 @@ private:
     std::string name_;
 
     bool destroy_on_unload_ = true;
+
+    Window* window_;
+    InputManager* input_;
+    Application* app_;
+    SceneManager* scene_manager_ = nullptr;
+
+    friend class SceneManager;
 };
 
 template<typename T>

--- a/simulant/scenes/scene.h
+++ b/simulant/scenes/scene.h
@@ -28,7 +28,7 @@
  *  manager->register_scene<GameScene>("ingame");
  *
  *  manager->activate_scene("loading");
- *  manager->load_scene_in_background("menu");
+ *  manager->load_in_background("menu");
  *  if(manager->is_loaded("menu")) {
  *      manager->activate_scene("menu");
  *  }

--- a/simulant/scenes/scene.h
+++ b/simulant/scenes/scene.h
@@ -27,13 +27,13 @@
  *  manager->register_scene<MenuScene>("menu");
  *  manager->register_scene<GameScene>("ingame");
  *
- *  manager->activate_scene("loading");
+ *  manager->activate("loading");
  *  manager->load_in_background("menu");
  *  if(manager->is_loaded("menu")) {
- *      manager->activate_scene("menu");
+ *      manager->activate("menu");
  *  }
  *  manager->unload("loading");
- *  manager->activate_scene("loading"); // Will cause loading to happen again
+ *  manager->activate("loading"); // Will cause loading to happen again
  *
  */
 

--- a/simulant/scenes/scene_manager.cpp
+++ b/simulant/scenes/scene_manager.cpp
@@ -148,7 +148,7 @@ void SceneManager::unload(const std::string& route) {
     }    
 }
 
-bool SceneManager::is_scene_loaded(const std::string& route) const {
+bool SceneManager::is_loaded(const std::string& route) const {
     auto it = routes_.find(route);
     if(it == routes_.end()) {
         return false;

--- a/simulant/scenes/scene_manager.cpp
+++ b/simulant/scenes/scene_manager.cpp
@@ -73,7 +73,7 @@ SceneBase::ptr SceneManager::active_scene() const {
     return current_scene_;
 }
 
-void SceneManager::activate_scene(const std::string& route, SceneChangeBehaviour behaviour) {
+void SceneManager::activate(const std::string& route, SceneChangeBehaviour behaviour) {
     auto new_scene = get_or_create_route(route);
 
     if(new_scene == current_scene_) {
@@ -130,7 +130,7 @@ void SceneManager::load_in_background(const std::string& route, bool redirect_af
 #endif
         new_task->future.get();
         if(redirect_after) {
-            activate_scene(route);
+            activate(route);
         }
 
         return false;

--- a/simulant/scenes/scene_manager.cpp
+++ b/simulant/scenes/scene_manager.cpp
@@ -93,16 +93,16 @@ void SceneManager::activate_scene(const std::string& route, SceneChangeBehaviour
 
     if(previous && behaviour == SCENE_CHANGE_BEHAVIOUR_UNLOAD_CURRENT_SCENE) {
         // If requested, we unload the previous scene once the new on is active
-        unload_scene(previous->name());
+        unload(previous->name());
     }
 }
 
-void SceneManager::load_scene(const std::string& route) {
+void SceneManager::load(const std::string& route) {
     auto scene = get_or_create_route(route);
     scene->_call_load();
 }
 
-void SceneManager::load_scene_in_background(const std::string& route, bool redirect_after) {
+void SceneManager::load_in_background(const std::string& route, bool redirect_after) {
     auto scene = get_or_create_route(route);
 
     //Create a background task for loading the scene
@@ -137,7 +137,7 @@ void SceneManager::load_scene_in_background(const std::string& route, bool redir
     });
 }
 
-void SceneManager::unload_scene(const std::string& route) {
+void SceneManager::unload(const std::string& route) {
     auto it = routes_.find(route);
     if(it != routes_.end()) {
         auto scene = it->second;

--- a/simulant/scenes/scene_manager.h
+++ b/simulant/scenes/scene_manager.h
@@ -56,7 +56,7 @@ public:
 
     bool has_scene(const std::string& route) const;
     SceneBasePtr resolve_scene(const std::string& route);
-    void activate_scene(const std::string& route, SceneChangeBehaviour behaviour=SCENE_CHANGE_BEHAVIOUR_UNLOAD_CURRENT_SCENE);
+    void activate(const std::string& route, SceneChangeBehaviour behaviour=SCENE_CHANGE_BEHAVIOUR_UNLOAD_CURRENT_SCENE);
 
     void load(const std::string& route);
     void load_in_background(const std::string& route, bool redirect_after=true);

--- a/simulant/scenes/scene_manager.h
+++ b/simulant/scenes/scene_manager.h
@@ -62,7 +62,7 @@ public:
     void load_in_background(const std::string& route, bool redirect_after=true);
     void unload(const std::string& route);
 
-    bool is_scene_loaded(const std::string& route) const;
+    bool is_loaded(const std::string& route) const;
     void reset();
     SceneBasePtr active_scene() const;
 

--- a/simulant/scenes/scene_manager.h
+++ b/simulant/scenes/scene_manager.h
@@ -58,9 +58,9 @@ public:
     SceneBasePtr resolve_scene(const std::string& route);
     void activate_scene(const std::string& route, SceneChangeBehaviour behaviour=SCENE_CHANGE_BEHAVIOUR_UNLOAD_CURRENT_SCENE);
 
-    void load_scene(const std::string& route);
-    void load_scene_in_background(const std::string& route, bool redirect_after=true);
-    void unload_scene(const std::string& route);
+    void load(const std::string& route);
+    void load_in_background(const std::string& route, bool redirect_after=true);
+    void unload(const std::string& route);
 
     bool is_scene_loaded(const std::string& route) const;
     void reset();

--- a/tests/test_screens.h
+++ b/tests/test_screens.h
@@ -112,7 +112,7 @@ public:
 
         TestScene* scr = dynamic_cast<TestScene*>(manager_->resolve_scene("main").get());
         assert_false(scr->load_called);
-        manager_->load_scene_in_background("main");
+        manager_->load_in_background("main");
 #ifdef _arch_dreamcast
         stdX::this_thread::sleep_for(std::chrono::milliseconds(100));
 #else

--- a/tests/test_screens.h
+++ b/tests/test_screens.h
@@ -69,12 +69,12 @@ public:
         assert_false(manager_->has_scene("main"));
     }
 
-    void test_activate_scene() {
-        assert_raises(std::logic_error, std::bind(&SceneManager::activate_scene, manager_, "main", smlt::SCENE_CHANGE_BEHAVIOUR_UNLOAD_CURRENT_SCENE));
+    void test_activate() {
+        assert_raises(std::logic_error, std::bind(&SceneManager::activate, manager_, "main", smlt::SCENE_CHANGE_BEHAVIOUR_UNLOAD_CURRENT_SCENE));
 
         manager_->register_scene<TestScene>("main");
 
-        manager_->activate_scene("main");
+        manager_->activate("main");
 
         TestScene* scr = dynamic_cast<TestScene*>(manager_->resolve_scene("main").get());
         scr->set_destroy_on_unload(false); //Don't destroy on unload
@@ -84,7 +84,7 @@ public:
         assert_false(scr->deactivate_called);
         assert_false(scr->unload_called);
 
-        manager_->activate_scene("main"); //activate_sceneing to the same place should do nothing
+        manager_->activate("main"); //activateing to the same place should do nothing
 
         assert_true(scr->load_called);
         assert_true(scr->activate_called);
@@ -92,7 +92,7 @@ public:
         assert_false(scr->unload_called);
 
         manager_->register_scene<TestScene>("/test");
-        manager_->activate_scene("/test");
+        manager_->activate("/test");
 
         assert_true(scr->load_called);
         assert_true(scr->activate_called);


### PR DESCRIPTION
# Summary of Changes Introduced

- `Application` is no longer a `SceneManager`, instead the internal `SceneManager` instance is exposed through the `scenes` property
- `Scene::scenes` now gives access to the owning `SceneManager`
- Some of the API naming has changed to take into account it will be accessed via `scenes` (e.g. `scenes->activate` rather than `scenes->activate_scene`
- Add documentation

# PR Checklist

- [x] I have documented any changes to the code in the documentation folder
- [x] I agree that the changes introduced in this PR are licensed under the [LGPL-3.0](https://opensource.org/licenses/LGPL-3.0)([Why?](../documentation/license.md))
- [x] I have added applicable tests, and not introduced any failures
