### PR TITLE
Make manual managers return pointers rather than IDs

### DIFF
--- a/samples/2d_sample.cpp
+++ b/samples/2d_sample.cpp
@@ -10,9 +10,9 @@ public:
         smlt::Scene<GameScene>(window) {}
 
     void load() {
-        prepare_basic_scene(stage_, camera_id_);
+        prepare_basic_scene(stage_, camera_);
 
-        auto cam = camera_id_.fetch();
+        auto cam = camera_;
 
         //Automatically calculate an orthographic projection, taking into account the aspect ratio
         //and the passed height. For example, passing a height of 2.0 would mean the view would extend
@@ -33,7 +33,7 @@ public:
             auto bounds = stage_->assets->mesh(mesh_id)->aabb();
 
             //Constrain the camera to the area where the sprite grid is rendered
-            stage_->camera(camera_id_)->constrain_to_aabb(
+            camera_->constrain_to_aabb(
                 AABB(
                     smlt::Vec3(render_width / 2, render_height / 2, 0),
                     smlt::Vec3(
@@ -53,7 +53,7 @@ public:
 
 private:
     StagePtr stage_;
-    CameraID camera_id_;
+    CameraPtr camera_;
 };
 
 

--- a/samples/2d_sample.cpp
+++ b/samples/2d_sample.cpp
@@ -10,7 +10,7 @@ public:
         smlt::Scene<GameScene>(window) {}
 
     void load() {
-        prepare_basic_scene(stage_id_, camera_id_);
+        prepare_basic_scene(stage_, camera_id_);
 
         auto cam = camera_id_.fetch();
 
@@ -23,19 +23,17 @@ public:
         );
 
         {
-            auto stage = window->stage(stage_id_);
-
             //Load a sprite grid, from the 'Layer 1' layer in a tmx file
-            smlt::MeshID mesh_id = stage->assets->new_mesh_from_tmx_file(
+            smlt::MeshID mesh_id = stage_->assets->new_mesh_from_tmx_file(
                 "sample_data/tiled/example.tmx", "Layer 1"
             );
 
-            stage->new_actor_with_mesh(mesh_id);
+            stage_->new_actor_with_mesh(mesh_id);
 
-            auto bounds = stage->assets->mesh(mesh_id)->aabb();
+            auto bounds = stage_->assets->mesh(mesh_id)->aabb();
 
             //Constrain the camera to the area where the sprite grid is rendered
-            stage->camera(camera_id_)->constrain_to_aabb(
+            stage_->camera(camera_id_)->constrain_to_aabb(
                 AABB(
                     smlt::Vec3(render_width / 2, render_height / 2, 0),
                     smlt::Vec3(
@@ -54,7 +52,7 @@ public:
     }
 
 private:
-    StageID stage_id_;
+    StagePtr stage_;
     CameraID camera_id_;
 };
 

--- a/samples/fleets_demo.cpp
+++ b/samples/fleets_demo.cpp
@@ -9,10 +9,10 @@ public:
         smlt::Scene<GameScene>(window) {}
 
     void load() {
-        auto pipeline = prepare_basic_scene(stage_, camera_id_);
+        auto pipeline = prepare_basic_scene(stage_, camera_);
         pipeline.fetch()->viewport->set_colour(smlt::Colour::BLACK);
 
-        camera_id_.fetch()->set_perspective_projection(Degrees(45.0), float(window->width()) / float(window->height()), 10.0, 10000.0);
+        camera_->set_perspective_projection(Degrees(45.0), float(window->width()) / float(window->height()), 10.0, 10000.0);
         ship_mesh_id_ = window->shared_assets->new_mesh_from_file("sample_data/fighter_good/space_frigate_6.obj");
         generate_ships();
 
@@ -36,12 +36,12 @@ public:
 
         avg /= ships_.size();
 
-        stage_->camera(camera_id_)->look_at(avg);
+        camera_->look_at(avg);
     }
 
 private:
     StagePtr stage_;
-    CameraID camera_id_;
+    CameraPtr camera_;
 
     MeshID ship_mesh_id_;
     std::vector<ActorPtr> ships_;

--- a/samples/fleets_demo.cpp
+++ b/samples/fleets_demo.cpp
@@ -9,16 +9,15 @@ public:
         smlt::Scene<GameScene>(window) {}
 
     void load() {
-        auto pipeline = prepare_basic_scene(stage_id_, camera_id_);
+        auto pipeline = prepare_basic_scene(stage_, camera_id_);
         pipeline.fetch()->viewport->set_colour(smlt::Colour::BLACK);
 
-        auto stage = window->stage(stage_id_);
         camera_id_.fetch()->set_perspective_projection(Degrees(45.0), float(window->width()) / float(window->height()), 10.0, 10000.0);
         ship_mesh_id_ = window->shared_assets->new_mesh_from_file("sample_data/fighter_good/space_frigate_6.obj");
         generate_ships();
 
-        stage->set_ambient_light(smlt::Colour(0.2, 0.2, 0.2, 1.0));
-        stage->new_light_as_directional();
+        stage_->set_ambient_light(smlt::Colour(0.2, 0.2, 0.2, 1.0));
+        stage_->new_light_as_directional();
     }
 
     void activate() {
@@ -27,10 +26,8 @@ public:
 
     void fixed_update(float dt) override {
         Vec3 speed(-250, 0, 0.0);
-
         Vec3 avg;
 
-        auto stage = window->stage(stage_id_);
         for(auto ship: ships_) {
             auto pos = ship->position();
             avg += pos;
@@ -39,11 +36,11 @@ public:
 
         avg /= ships_.size();
 
-        stage->camera(camera_id_)->look_at(avg);
+        stage_->camera(camera_id_)->look_at(avg);
     }
 
 private:
-    StageID stage_id_;
+    StagePtr stage_;
     CameraID camera_id_;
 
     MeshID ship_mesh_id_;
@@ -59,11 +56,10 @@ private:
                 random_gen::random_float(-100, 100)
             ).normalized() * random_gen::random_float(100.0f, 150.0f));
 
-            auto stage = window->stage(stage_id_);
-            ships_.push_back(stage->new_actor_with_mesh(ship_mesh_id_));
+            ships_.push_back(stage_->new_actor_with_mesh(ship_mesh_id_));
             ships_.back()->move_to_absolute(pos);
 
-            auto ps = stage->new_particle_system_with_parent_from_file(ships_.back()->id(), "simulant/particles/pixel_trail.kglp");
+            auto ps = stage_->new_particle_system_with_parent_from_file(ships_.back()->id(), "simulant/particles/pixel_trail.kglp");
             ps->move_to(0, 0, 0);
         }
     }

--- a/samples/fleets_demo.cpp
+++ b/samples/fleets_demo.cpp
@@ -10,7 +10,7 @@ public:
 
     void load() {
         auto pipeline = prepare_basic_scene(stage_, camera_);
-        pipeline.fetch()->viewport->set_colour(smlt::Colour::BLACK);
+        pipeline->viewport->set_colour(smlt::Colour::BLACK);
 
         camera_->set_perspective_projection(Degrees(45.0), float(window->width()) / float(window->height()), 10.0, 10000.0);
         ship_mesh_id_ = window->shared_assets->new_mesh_from_file("sample_data/fighter_good/space_frigate_6.obj");

--- a/samples/fleets_demo.cpp
+++ b/samples/fleets_demo.cpp
@@ -63,8 +63,8 @@ private:
             ships_.push_back(stage->new_actor_with_mesh(ship_mesh_id_));
             ships_.back()->move_to_absolute(pos);
 
-            auto ps_id = stage->new_particle_system_with_parent_from_file(ships_.back()->id(), "simulant/particles/pixel_trail.kglp");
-            stage->particle_system(ps_id)->move_to(0, 0, 0);
+            auto ps = stage->new_particle_system_with_parent_from_file(ships_.back()->id(), "simulant/particles/pixel_trail.kglp");
+            ps->move_to(0, 0, 0);
         }
     }
 };

--- a/samples/fleets_demo.cpp
+++ b/samples/fleets_demo.cpp
@@ -31,13 +31,13 @@ public:
         Vec3 avg;
 
         auto stage = window->stage(stage_id_);
-        for(auto ship_id: ship_ids_) {
-            auto pos = stage->actor(ship_id)->position();
+        for(auto ship: ships_) {
+            auto pos = ship->position();
             avg += pos;
-            stage->actor(ship_id)->move_to_absolute(pos + (speed * dt * (0.01 * ship_id.value())));
+            ship->move_to_absolute(pos + (speed * dt * (0.01 * ship->id().value())));
         }
 
-        avg /= ship_ids_.size();
+        avg /= ships_.size();
 
         stage->camera(camera_id_)->look_at(avg);
     }
@@ -47,7 +47,7 @@ private:
     CameraID camera_id_;
 
     MeshID ship_mesh_id_;
-    std::vector<ActorID> ship_ids_;
+    std::vector<ActorPtr> ships_;
 
     void generate_ships() {
         Vec3 centre = Vec3(2000, 0, 0);
@@ -60,10 +60,10 @@ private:
             ).normalized() * random_gen::random_float(100.0f, 150.0f));
 
             auto stage = window->stage(stage_id_);
-            ship_ids_.push_back(stage->new_actor_with_mesh(ship_mesh_id_));
-            stage->actor(ship_ids_.back())->move_to_absolute(pos);
+            ships_.push_back(stage->new_actor_with_mesh(ship_mesh_id_));
+            ships_.back()->move_to_absolute(pos);
 
-            auto ps_id = stage->new_particle_system_with_parent_from_file(ship_ids_.back(), "simulant/particles/pixel_trail.kglp");
+            auto ps_id = stage->new_particle_system_with_parent_from_file(ships_.back()->id(), "simulant/particles/pixel_trail.kglp");
             stage->particle_system(ps_id)->move_to(0, 0, 0);
         }
     }

--- a/samples/light_sample.cpp
+++ b/samples/light_sample.cpp
@@ -10,9 +10,9 @@ public:
         smlt::Scene<GameScene>(window) {}
 
     void load() {
-        prepare_basic_scene(stage_, camera_id_);
+        prepare_basic_scene(stage_, camera_);
 
-        camera_id_.fetch()->set_perspective_projection(
+        camera_->set_perspective_projection(
             Degrees(45.0),
             float(window->width()) / float(window->height()),
             0.1,
@@ -30,7 +30,7 @@ public:
         actor_->mesh()->set_texture_on_material(0, texture_);
 
         // Test Camera::look_at function
-        stage_->camera(camera_id_)->look_at(actor_->absolute_position());
+        camera_->look_at(actor_->absolute_position());
 
         {
             auto light = stage_->new_light_as_point(Vec3(5, 0, -5), smlt::Colour::GREEN);
@@ -74,7 +74,7 @@ public:
     }
 
 private:
-    CameraID camera_id_;
+    CameraPtr camera_;
     StagePtr stage_;
     ActorPtr actor_;
     TextureID texture_;

--- a/samples/light_sample.cpp
+++ b/samples/light_sample.cpp
@@ -10,8 +10,7 @@ public:
         smlt::Scene<GameScene>(window) {}
 
     void load() {
-        prepare_basic_scene(stage_id_, camera_id_);
-        auto stage = window->stage(stage_id_);
+        prepare_basic_scene(stage_, camera_id_);
 
         camera_id_.fetch()->set_perspective_projection(
             Degrees(45.0),
@@ -20,30 +19,30 @@ public:
             1000.0
         );
 
-        stage->set_ambient_light(smlt::Colour(0.2, 0.2, 0.2, 1.0));
+        stage_->set_ambient_light(smlt::Colour(0.2, 0.2, 0.2, 1.0));
 
-        actor_ = stage->new_actor_with_mesh(stage->assets->new_mesh_as_cube(2.0));
+        actor_ = stage_->new_actor_with_mesh(stage_->assets->new_mesh_as_cube(2.0));
         actor_->move_to(0.0, 0.0, -5.0);
 
-        texture_ = stage->assets->new_texture_from_file("sample_data/crate.png");
+        texture_ = stage_->assets->new_texture_from_file("sample_data/crate.png");
         texture_.fetch()->set_texture_filter(TEXTURE_FILTER_BILINEAR);
 
         actor_->mesh()->set_texture_on_material(0, texture_);
 
         // Test Camera::look_at function
-        stage->camera(camera_id_)->look_at(actor_->absolute_position());
+        stage_->camera(camera_id_)->look_at(actor_->absolute_position());
 
         {
-            auto light = stage->new_light_as_point(Vec3(5, 0, -5), smlt::Colour::GREEN);
+            auto light = stage_->new_light_as_point(Vec3(5, 0, -5), smlt::Colour::GREEN);
             light->set_attenuation_from_range(20.0);
 
-            auto light2 = stage->new_light_as_point(Vec3(-5, 0, -5), smlt::Colour::BLUE);
+            auto light2 = stage_->new_light_as_point(Vec3(-5, 0, -5), smlt::Colour::BLUE);
             light2->set_attenuation_from_range(30.0);
 
-            auto light3 = stage->new_light_as_point(Vec3(0, -15, -5), smlt::Colour::RED);
+            auto light3 = stage_->new_light_as_point(Vec3(0, -15, -5), smlt::Colour::RED);
             light3->set_attenuation_from_range(50.0);
 
-            stage->new_light_as_directional(Vec3(1, 0, 0), smlt::Colour::YELLOW);
+            stage_->new_light_as_directional(Vec3(1, 0, 0), smlt::Colour::YELLOW);
         }
 
         window->new_background_as_scrollable_from_file("sample_data/background.png");        
@@ -76,7 +75,7 @@ public:
 
 private:
     CameraID camera_id_;
-    StageID stage_id_;
+    StagePtr stage_;
     ActorPtr actor_;
     TextureID texture_;
 

--- a/samples/light_sample.cpp
+++ b/samples/light_sample.cpp
@@ -34,13 +34,13 @@ public:
         stage->camera(camera_id_)->look_at(actor_->absolute_position());
 
         {
-            auto light = stage->new_light_as_point(Vec3(5, 0, -5), smlt::Colour::GREEN).fetch();
+            auto light = stage->new_light_as_point(Vec3(5, 0, -5), smlt::Colour::GREEN);
             light->set_attenuation_from_range(20.0);
 
-            auto light2 = stage->new_light_as_point(Vec3(-5, 0, -5), smlt::Colour::BLUE).fetch();
+            auto light2 = stage->new_light_as_point(Vec3(-5, 0, -5), smlt::Colour::BLUE);
             light2->set_attenuation_from_range(30.0);
 
-            auto light3 = stage->new_light_as_point(Vec3(0, -15, -5), smlt::Colour::RED).fetch();
+            auto light3 = stage->new_light_as_point(Vec3(0, -15, -5), smlt::Colour::RED);
             light3->set_attenuation_from_range(50.0);
 
             stage->new_light_as_directional(Vec3(1, 0, 0), smlt::Colour::YELLOW);

--- a/samples/light_sample.cpp
+++ b/samples/light_sample.cpp
@@ -22,16 +22,16 @@ public:
 
         stage->set_ambient_light(smlt::Colour(0.2, 0.2, 0.2, 1.0));
 
-        actor_id_ = stage->new_actor_with_mesh(stage->assets->new_mesh_as_cube(2.0));
-        stage->actor(actor_id_)->move_to(0.0, 0.0, -5.0);
+        actor_ = stage->new_actor_with_mesh(stage->assets->new_mesh_as_cube(2.0));
+        actor_->move_to(0.0, 0.0, -5.0);
 
         texture_ = stage->assets->new_texture_from_file("sample_data/crate.png");
         texture_.fetch()->set_texture_filter(TEXTURE_FILTER_BILINEAR);
 
-        stage->actor(actor_id_)->mesh()->set_texture_on_material(0, texture_);
+        actor_->mesh()->set_texture_on_material(0, texture_);
 
         // Test Camera::look_at function
-        stage->camera(camera_id_)->look_at(stage->actor(actor_id_)->absolute_position());
+        stage->camera(camera_id_)->look_at(actor_->absolute_position());
 
         {
             auto light = stage->new_light_as_point(Vec3(5, 0, -5), smlt::Colour::GREEN).fetch();
@@ -67,17 +67,17 @@ public:
     }
 
     void fixed_update(float dt) {
-        actor_id_.fetch()->rotate_global_y_by(smlt::Degrees(input->axis_value("Horizontal") * 360.0f * dt));
+        actor_->rotate_global_y_by(smlt::Degrees(input->axis_value("Horizontal") * 360.0f * dt));
 
-        window->stage(stage_id_)->actor(actor_id_)->rotate_x_by(smlt::Degrees(dt * 20.0));
-        window->stage(stage_id_)->actor(actor_id_)->rotate_y_by(smlt::Degrees(dt * 15.0));
-        window->stage(stage_id_)->actor(actor_id_)->rotate_z_by(smlt::Degrees(dt * 25.0));
+        actor_->rotate_x_by(smlt::Degrees(dt * 20.0));
+        actor_->rotate_y_by(smlt::Degrees(dt * 15.0));
+        actor_->rotate_z_by(smlt::Degrees(dt * 25.0));
     }
 
 private:
     CameraID camera_id_;
     StageID stage_id_;
-    ActorID actor_id_;
+    ActorPtr actor_;
     TextureID texture_;
 
     bool f_down = false;

--- a/samples/nehe01.cpp
+++ b/samples/nehe01.cpp
@@ -9,10 +9,9 @@ public:
     void load() {
         prepare_basic_scene(stage_, camera_);
 
-        smlt::StagePtr stage = stage_.fetch();
-        smlt::MeshPtr square = stage->assets->new_mesh_as_rectangle(1.0, 1.0).fetch();
+        smlt::MeshPtr square = stage_->assets->new_mesh_as_rectangle(1.0, 1.0).fetch();
 
-        auto actor = stage->new_actor_with_mesh(square->id());
+        auto actor = stage_->new_actor_with_mesh(square->id());
         actor->move_to(0, 0, -5);
         actor->scale_by(2.0);
 
@@ -20,7 +19,7 @@ public:
     }
 
 private:
-    smlt::StageID stage_;
+    smlt::StagePtr stage_;
     smlt::CameraID camera_;
 };
 

--- a/samples/nehe01.cpp
+++ b/samples/nehe01.cpp
@@ -12,7 +12,7 @@ public:
         smlt::StagePtr stage = stage_.fetch();
         smlt::MeshPtr square = stage->assets->new_mesh_as_rectangle(1.0, 1.0).fetch();
 
-        auto actor = stage->new_actor_with_mesh(square->id()).fetch();
+        auto actor = stage->new_actor_with_mesh(square->id());
         actor->move_to(0, 0, -5);
         actor->scale_by(2.0);
 

--- a/samples/nehe01.cpp
+++ b/samples/nehe01.cpp
@@ -20,7 +20,7 @@ public:
 
 private:
     smlt::StagePtr stage_;
-    smlt::CameraID camera_;
+    smlt::CameraPtr camera_;
 };
 
 class App : public smlt::Application {

--- a/samples/particles.cpp
+++ b/samples/particles.cpp
@@ -11,7 +11,7 @@ public:
 
         smlt::StagePtr stage = stage_.fetch();
 
-        auto ps = stage->new_particle_system_from_file("simulant/particles/fire.kglp").fetch();
+        auto ps = stage->new_particle_system_from_file("simulant/particles/fire.kglp");
         ps->move_to(0.0, 0, -4);
 
         auto mat = stage->assets->new_material_from_file(smlt::Material::BuiltIns::TEXTURED_PARTICLE).fetch();

--- a/samples/particles.cpp
+++ b/samples/particles.cpp
@@ -9,14 +9,12 @@ public:
     void load() {
         prepare_basic_scene(stage_, camera_);
 
-        smlt::StagePtr stage = stage_.fetch();
-
-        auto ps = stage->new_particle_system_from_file("simulant/particles/fire.kglp");
+        auto ps = stage_->new_particle_system_from_file("simulant/particles/fire.kglp");
         ps->move_to(0.0, 0, -4);
 
-        auto mat = stage->assets->new_material_from_file(smlt::Material::BuiltIns::TEXTURED_PARTICLE).fetch();
+        auto mat = stage_->assets->new_material_from_file(smlt::Material::BuiltIns::TEXTURED_PARTICLE).fetch();
         ps->set_material_id(mat->id());
-        mat->set_texture_unit_on_all_passes(0, stage->assets->new_texture_from_file("sample_data/flare.tga"));
+        mat->set_texture_unit_on_all_passes(0, stage_->assets->new_texture_from_file("sample_data/flare.tga"));
 
         camera_.fetch()->set_perspective_projection(
             smlt::Degrees(45.0),
@@ -29,7 +27,7 @@ public:
     }
 
 private:
-    smlt::StageID stage_;
+    smlt::StagePtr stage_;
     smlt::CameraID camera_;
 };
 

--- a/samples/particles.cpp
+++ b/samples/particles.cpp
@@ -16,7 +16,7 @@ public:
         ps->set_material_id(mat->id());
         mat->set_texture_unit_on_all_passes(0, stage_->assets->new_texture_from_file("sample_data/flare.tga"));
 
-        camera_.fetch()->set_perspective_projection(
+        camera_->set_perspective_projection(
             smlt::Degrees(45.0),
             float(window->width()) / float(window->height()),
             0.1,
@@ -28,7 +28,7 @@ public:
 
 private:
     smlt::StagePtr stage_;
-    smlt::CameraID camera_;
+    smlt::CameraPtr camera_;
 };
 
 class App : public smlt::Application {

--- a/samples/physics_demo.cpp
+++ b/samples/physics_demo.cpp
@@ -13,21 +13,19 @@ public:
         smlt::PhysicsScene<GameScene>(window) {}
 
     void load() {
-        pipeline_id_ = prepare_basic_scene(stage_id_, camera_id_, smlt::PARTITIONER_NULL);
+        pipeline_id_ = prepare_basic_scene(stage_, camera_id_, smlt::PARTITIONER_NULL);
         window->disable_pipeline(pipeline_id_);
-
-        auto stage = window->stage(stage_id_);
 
         camera_id_.fetch()->set_perspective_projection(
             Degrees(45.0), float(window->width()) / float(window->height()), 1.0, 1000.0
         );
 
-        stage->camera(camera_id_)->move_to(0, 10, 50);
+        stage_->camera(camera_id_)->move_to(0, 10, 50);
 
         window->pipeline(pipeline_id_)->viewport->set_colour(smlt::Colour::SKY_BLUE);
 
         // Create a nice skybox
-        stage->skies->new_skybox_from_folder("sample_data/skyboxes/TropicalSunnyDay");
+        stage_->skies->new_skybox_from_folder("sample_data/skyboxes/TropicalSunnyDay");
 
         smlt::TextureID crate = window->shared_assets->new_texture_from_file("sample_data/crate.png");
         smlt::MaterialID mat = window->shared_assets->new_material_from_texture(crate);
@@ -40,7 +38,7 @@ public:
         window->shared_assets->mesh(ground_mesh_id_)->set_material_id(
             window->shared_assets->new_material_from_texture(grass)
         );
-        ground_ = stage->new_actor_with_mesh(ground_mesh_id_);
+        ground_ = stage_->new_actor_with_mesh(ground_mesh_id_);
 
         // Make the ground a staticbody
         auto c = ground_->new_behaviour<behaviours::StaticBody>(physics);
@@ -51,7 +49,7 @@ public:
 
     void spawn_box() {
         boxes_.push_back(
-            stage_id_.fetch()->new_actor_with_mesh(box_mesh_id_)
+            stage_->new_actor_with_mesh(box_mesh_id_)
         );
 
         auto box = boxes_.back();
@@ -79,7 +77,7 @@ private:
     std::vector<ActorPtr> boxes_;
 
     PipelineID pipeline_id_;
-    StageID stage_id_;
+    StagePtr stage_;
     CameraID camera_id_;
 
     MeshID box_mesh_id_;

--- a/samples/physics_demo.cpp
+++ b/samples/physics_demo.cpp
@@ -40,11 +40,11 @@ public:
         window->shared_assets->mesh(ground_mesh_id_)->set_material_id(
             window->shared_assets->new_material_from_texture(grass)
         );
-        ground_id_ = stage->new_actor_with_mesh(ground_mesh_id_);
+        ground_ = stage->new_actor_with_mesh(ground_mesh_id_);
 
         // Make the ground a staticbody
-        auto c = ground_id_.fetch()->new_behaviour<behaviours::StaticBody>(physics);
-        c->add_box_collider(ground_id_.fetch()->aabb().dimensions(), behaviours::PhysicsMaterial::STONE);
+        auto c = ground_->new_behaviour<behaviours::StaticBody>(physics);
+        c->add_box_collider(ground_->aabb().dimensions(), behaviours::PhysicsMaterial::STONE);
 
         srand(time(nullptr));
     }
@@ -54,7 +54,7 @@ public:
             stage_id_.fetch()->new_actor_with_mesh(box_mesh_id_)
         );
 
-        auto box = boxes_.back().fetch();
+        auto box = boxes_.back();
         auto controller = box->new_behaviour<smlt::behaviours::RigidBody>(physics);
         controller->add_box_collider(box->aabb().dimensions(), behaviours::PhysicsMaterial::WOOD);
         controller->move_to(Vec3(
@@ -76,7 +76,7 @@ public:
     }
 
 private:
-    std::vector<ActorID> boxes_;
+    std::vector<ActorPtr> boxes_;
 
     PipelineID pipeline_id_;
     StageID stage_id_;
@@ -85,7 +85,7 @@ private:
     MeshID box_mesh_id_;
 
     MeshID ground_mesh_id_;
-    ActorID ground_id_;
+    ActorPtr ground_;
 
     float counter = 0.0f;
 };

--- a/samples/physics_demo.cpp
+++ b/samples/physics_demo.cpp
@@ -13,16 +13,15 @@ public:
         smlt::PhysicsScene<GameScene>(window) {}
 
     void load() {
-        pipeline_id_ = prepare_basic_scene(stage_, camera_, smlt::PARTITIONER_NULL);
-        window->disable_pipeline(pipeline_id_);
+        pipeline_ = prepare_basic_scene(stage_, camera_, smlt::PARTITIONER_NULL);
+        pipeline_->deactivate();
+        pipeline_->viewport->set_colour(smlt::Colour::SKY_BLUE);
 
         camera_->set_perspective_projection(
             Degrees(45.0), float(window->width()) / float(window->height()), 1.0, 1000.0
         );
 
         camera_->move_to(0, 10, 50);
-
-        window->pipeline(pipeline_id_)->viewport->set_colour(smlt::Colour::SKY_BLUE);
 
         // Create a nice skybox
         stage_->skies->new_skybox_from_folder("sample_data/skyboxes/TropicalSunnyDay");
@@ -62,7 +61,7 @@ public:
     }
 
     void activate() {
-        window->enable_pipeline(pipeline_id_);
+        pipeline_->activate();
     }
 
     void update(float dt) {
@@ -76,7 +75,7 @@ public:
 private:
     std::vector<ActorPtr> boxes_;
 
-    PipelineID pipeline_id_;
+    PipelinePtr pipeline_;
     StagePtr stage_;
     CameraPtr camera_;
 

--- a/samples/physics_demo.cpp
+++ b/samples/physics_demo.cpp
@@ -13,14 +13,14 @@ public:
         smlt::PhysicsScene<GameScene>(window) {}
 
     void load() {
-        pipeline_id_ = prepare_basic_scene(stage_, camera_id_, smlt::PARTITIONER_NULL);
+        pipeline_id_ = prepare_basic_scene(stage_, camera_, smlt::PARTITIONER_NULL);
         window->disable_pipeline(pipeline_id_);
 
-        camera_id_.fetch()->set_perspective_projection(
+        camera_->set_perspective_projection(
             Degrees(45.0), float(window->width()) / float(window->height()), 1.0, 1000.0
         );
 
-        stage_->camera(camera_id_)->move_to(0, 10, 50);
+        camera_->move_to(0, 10, 50);
 
         window->pipeline(pipeline_id_)->viewport->set_colour(smlt::Colour::SKY_BLUE);
 
@@ -78,7 +78,7 @@ private:
 
     PipelineID pipeline_id_;
     StagePtr stage_;
-    CameraID camera_id_;
+    CameraPtr camera_;
 
     MeshID box_mesh_id_;
 

--- a/samples/q2bsp_sample.cpp
+++ b/samples/q2bsp_sample.cpp
@@ -10,10 +10,10 @@ public:
         smlt::Scene<GameScene>(window) {}
 
     void load() {
-        pid_ = prepare_basic_scene(stage_, camera_);
-        window->pipeline(pid_)->set_clear_flags(BUFFER_CLEAR_ALL);
-        window->pipeline(pid_)->viewport->set_colour(smlt::Colour::GREY);
-        window->disable_pipeline(pid_);
+        pipeline_ = prepare_basic_scene(stage_, camera_);
+        pipeline_->set_clear_flags(BUFFER_CLEAR_ALL);
+        pipeline_->viewport->set_colour(smlt::Colour::GREY);
+        pipeline_->deactivate();
 
         window->resource_locator->add_search_path("sample_data/q2");
 
@@ -38,13 +38,13 @@ public:
     }
 
     void activate() {
-        window->enable_pipeline(pid_);
+        pipeline_->activate();
     }
 
 private:
     StagePtr stage_;
     CameraPtr camera_;
-    PipelineID pid_;
+    PipelinePtr pipeline_;
 };
 
 

--- a/samples/q2bsp_sample.cpp
+++ b/samples/q2bsp_sample.cpp
@@ -10,7 +10,7 @@ public:
         smlt::Scene<GameScene>(window) {}
 
     void load() {
-        pid_ = prepare_basic_scene(stage_, camera_id_);
+        pid_ = prepare_basic_scene(stage_, camera_);
         window->pipeline(pid_)->set_clear_flags(BUFFER_CLEAR_ALL);
         window->pipeline(pid_)->viewport->set_colour(smlt::Colour::GREY);
         window->disable_pipeline(pid_);
@@ -25,9 +25,9 @@ public:
         );*/
 
         // Add a fly controller to the camera for user input
-        stage_->camera(camera_id_)->new_behaviour<behaviours::Fly>(window);
+        camera_->new_behaviour<behaviours::Fly>(window);
 
-        camera_id_.fetch()->set_perspective_projection(
+        camera_->set_perspective_projection(
             Degrees(45.0),
             float(window->width()) / float(window->height()),
             1.0,
@@ -43,7 +43,7 @@ public:
 
 private:
     StagePtr stage_;
-    CameraID camera_id_;
+    CameraPtr camera_;
     PipelineID pid_;
 };
 

--- a/samples/q2bsp_sample.cpp
+++ b/samples/q2bsp_sample.cpp
@@ -10,23 +10,22 @@ public:
         smlt::Scene<GameScene>(window) {}
 
     void load() {
-        pid_ = prepare_basic_scene(stage_id_, camera_id_);
+        pid_ = prepare_basic_scene(stage_, camera_id_);
         window->pipeline(pid_)->set_clear_flags(BUFFER_CLEAR_ALL);
         window->pipeline(pid_)->viewport->set_colour(smlt::Colour::GREY);
         window->disable_pipeline(pid_);
 
-        auto stage = window->stage(stage_id_);
         window->resource_locator->add_search_path("sample_data/q2");
 
-        auto mesh = stage->assets->new_mesh_from_file("sample_data/sample.bsp").fetch();
-        auto actor_id = stage->new_actor_with_mesh(mesh->id());
+        auto mesh = stage_->assets->new_mesh_from_file("sample_data/sample.bsp").fetch();
+        auto actor_id = stage_->new_actor_with_mesh(mesh->id());
         /*
         stage->camera(camera_id_)->move_to_absolute(
             mesh->data->get<smlt::Vec3>("player_spawn")
         );*/
 
         // Add a fly controller to the camera for user input
-        stage->camera(camera_id_)->new_behaviour<behaviours::Fly>(window);
+        stage_->camera(camera_id_)->new_behaviour<behaviours::Fly>(window);
 
         camera_id_.fetch()->set_perspective_projection(
             Degrees(45.0),
@@ -35,7 +34,7 @@ public:
             1000.0
         );
 
-        stage->set_ambient_light(smlt::Colour(0.8, 0.8, 0.8, 1.0));
+        stage_->set_ambient_light(smlt::Colour(0.8, 0.8, 0.8, 1.0));
     }
 
     void activate() {
@@ -43,7 +42,7 @@ public:
     }
 
 private:
-    StageID stage_id_;
+    StagePtr stage_;
     CameraID camera_id_;
     PipelineID pid_;
 };

--- a/samples/rtt_sample.cpp
+++ b/samples/rtt_sample.cpp
@@ -9,26 +9,26 @@ public:
 
     void load() {
         cube_stage_ = window->new_stage();        
-        auto cube_cam = cube_stage_.fetch()->new_camera().fetch();
+        auto cube_cam = cube_stage_->new_camera().fetch();
 
         rect_stage_ = window->new_stage();
-        auto rect_cam = rect_stage_.fetch()->new_camera().fetch();
+        auto rect_cam = rect_stage_->new_camera().fetch();
 
         smlt::TextureID tid = window->shared_assets->new_texture_from_file("sample_data/sample.tga");
         MeshID cube_mesh = window->shared_assets->new_mesh_as_cube(1.0);
         window->shared_assets->mesh(cube_mesh)->set_texture_on_material(0, tid);
-        cube_ = window->stage(cube_stage_)->new_actor_with_mesh(cube_mesh);
+        cube_ = cube_stage_->new_actor_with_mesh(cube_mesh);
         cube_->move_to_absolute(0, 0, -4);
 
         MeshID rect_mesh = window->shared_assets->new_mesh_as_rectangle(2.0, 2.0);
-        rect_ = window->stage(rect_stage_)->new_actor_with_mesh(rect_mesh);
+        rect_ = rect_stage_->new_actor_with_mesh(rect_mesh);
         rect_->move_to_absolute(0, 0, -4);
 
         TextureID rtt = window->shared_assets->new_texture(smlt::GARBAGE_COLLECT_NEVER);
         window->shared_assets->mesh(rect_mesh)->set_texture_on_material(0, rtt);
 
-        window->render(cube_stage_, cube_cam->id()).to_texture(rtt);
-        window->render(rect_stage_, rect_cam->id()).to_framebuffer(
+        window->render(cube_stage_->id(), cube_cam->id()).to_texture(rtt);
+        window->render(rect_stage_->id(), rect_cam->id()).to_framebuffer(
             Viewport(VIEWPORT_TYPE_FULL, smlt::Colour::GREY)
         ).with_clear();
     }
@@ -39,7 +39,7 @@ public:
     }
 
 private:
-    StageID cube_stage_, rect_stage_;
+    StagePtr cube_stage_, rect_stage_;
     ActorPtr cube_ = nullptr;
     ActorPtr rect_ = nullptr;
 };

--- a/samples/rtt_sample.cpp
+++ b/samples/rtt_sample.cpp
@@ -18,11 +18,11 @@ public:
         MeshID cube_mesh = window->shared_assets->new_mesh_as_cube(1.0);
         window->shared_assets->mesh(cube_mesh)->set_texture_on_material(0, tid);
         cube_ = window->stage(cube_stage_)->new_actor_with_mesh(cube_mesh);
-        window->stage(cube_stage_)->actor(cube_)->move_to_absolute(0, 0, -4);
+        cube_->move_to_absolute(0, 0, -4);
 
         MeshID rect_mesh = window->shared_assets->new_mesh_as_rectangle(2.0, 2.0);
         rect_ = window->stage(rect_stage_)->new_actor_with_mesh(rect_mesh);
-        window->stage(rect_stage_)->actor(rect_)->move_to_absolute(0, 0, -4);
+        rect_->move_to_absolute(0, 0, -4);
 
         TextureID rtt = window->shared_assets->new_texture(smlt::GARBAGE_COLLECT_NEVER);
         window->shared_assets->mesh(rect_mesh)->set_texture_on_material(0, rtt);
@@ -34,13 +34,14 @@ public:
     }
 
     void fixed_update(float dt) {
-        window->stage(cube_stage_)->actor(cube_)->rotate_y_by(Degrees(dt * 360));
-        window->stage(rect_stage_)->actor(rect_)->rotate_y_by(Degrees(dt * 180));
+        cube_->rotate_y_by(Degrees(dt * 360));
+        rect_->rotate_y_by(Degrees(dt * 180));
     }
 
 private:
     StageID cube_stage_, rect_stage_;
-    ActorID cube_, rect_;
+    ActorPtr cube_ = nullptr;
+    ActorPtr rect_ = nullptr;
 };
 
 class Sample: public smlt::Application {

--- a/samples/rtt_sample.cpp
+++ b/samples/rtt_sample.cpp
@@ -9,10 +9,10 @@ public:
 
     void load() {
         cube_stage_ = window->new_stage();        
-        auto cube_cam = cube_stage_->new_camera().fetch();
+        auto cube_cam = cube_stage_->new_camera();
 
         rect_stage_ = window->new_stage();
-        auto rect_cam = rect_stage_->new_camera().fetch();
+        auto rect_cam = rect_stage_->new_camera();
 
         smlt::TextureID tid = window->shared_assets->new_texture_from_file("sample_data/sample.tga");
         MeshID cube_mesh = window->shared_assets->new_mesh_as_cube(1.0);

--- a/samples/sample.cpp
+++ b/samples/sample.cpp
@@ -8,11 +8,11 @@ public:
         smlt::Scene<GameScene>(window) {}
 
     void load() {
-        auto pipeline_id = prepare_basic_scene(stage_, camera_id_, smlt::PARTITIONER_NULL);
+        auto pipeline_id = prepare_basic_scene(stage_, camera_, smlt::PARTITIONER_NULL);
 
         window->pipeline(pipeline_id)->viewport->set_colour(smlt::Colour::SKY_BLUE);
 
-        camera_id_.fetch()->set_perspective_projection(
+        camera_->set_perspective_projection(
             Degrees(45.0),
             float(window->width()) / float(window->height()),
             1.0,
@@ -43,7 +43,7 @@ public:
     }
 
 private:
-    CameraID camera_id_;
+    CameraPtr camera_;
     StagePtr stage_;
 };
 

--- a/samples/sample.cpp
+++ b/samples/sample.cpp
@@ -26,11 +26,11 @@ public:
         // Load an animated MD2 mesh
         smlt::MeshID mesh_id = stage->assets->new_mesh_from_file("sample_data/ogro.md2");
 
-        auto actor = stage->new_actor_with_mesh(mesh_id).fetch(); // Create an instance of it
+        auto actor = stage->new_actor_with_mesh(mesh_id); // Create an instance of it
         actor->move_to(0.0f, 0.0f, -80.0f);
         actor->rotate_global_y_by(smlt::Degrees(180));
 
-        auto actor3 = stage->new_actor_with_mesh(mesh_id).fetch();
+        auto actor3 = stage->new_actor_with_mesh(mesh_id);
         actor3->move_to(-40.0f, 0.0f, -95.0f);
         actor3->rotate_global_y_by(smlt::Degrees(180));
         actor3->animation_state->play_animation("idle_2");
@@ -40,7 +40,7 @@ public:
         auto tank = stage->assets->new_mesh_from_file("sample_data/tank.obj").fetch();
         tank->transform_vertices(scaling_matrix);
 
-        auto tank_actor = stage->new_actor_with_mesh(tank->id()).fetch();
+        auto tank_actor = stage->new_actor_with_mesh(tank->id());
         tank_actor->move_to(40, 0, -110);
     }
 

--- a/samples/sample.cpp
+++ b/samples/sample.cpp
@@ -8,11 +8,9 @@ public:
         smlt::Scene<GameScene>(window) {}
 
     void load() {
-        auto pipeline_id = prepare_basic_scene(stage_id_, camera_id_, smlt::PARTITIONER_NULL);
+        auto pipeline_id = prepare_basic_scene(stage_, camera_id_, smlt::PARTITIONER_NULL);
 
         window->pipeline(pipeline_id)->viewport->set_colour(smlt::Colour::SKY_BLUE);
-
-        auto stage = window->stage(stage_id_);
 
         camera_id_.fetch()->set_perspective_projection(
             Degrees(45.0),
@@ -21,32 +19,32 @@ public:
             1000.0
         );
 
-        stage->set_ambient_light(smlt::Colour::WHITE);
+        stage_->set_ambient_light(smlt::Colour::WHITE);
 
         // Load an animated MD2 mesh
-        smlt::MeshID mesh_id = stage->assets->new_mesh_from_file("sample_data/ogro.md2");
+        smlt::MeshID mesh_id = stage_->assets->new_mesh_from_file("sample_data/ogro.md2");
 
-        auto actor = stage->new_actor_with_mesh(mesh_id); // Create an instance of it
+        auto actor = stage_->new_actor_with_mesh(mesh_id); // Create an instance of it
         actor->move_to(0.0f, 0.0f, -80.0f);
         actor->rotate_global_y_by(smlt::Degrees(180));
 
-        auto actor3 = stage->new_actor_with_mesh(mesh_id);
+        auto actor3 = stage_->new_actor_with_mesh(mesh_id);
         actor3->move_to(-40.0f, 0.0f, -95.0f);
         actor3->rotate_global_y_by(smlt::Degrees(180));
         actor3->animation_state->play_animation("idle_2");
 
         auto scaling_matrix = smlt::Mat4::as_scaling(10.0);
 
-        auto tank = stage->assets->new_mesh_from_file("sample_data/tank.obj").fetch();
+        auto tank = stage_->assets->new_mesh_from_file("sample_data/tank.obj").fetch();
         tank->transform_vertices(scaling_matrix);
 
-        auto tank_actor = stage->new_actor_with_mesh(tank->id());
+        auto tank_actor = stage_->new_actor_with_mesh(tank->id());
         tank_actor->move_to(40, 0, -110);
     }
 
 private:
     CameraID camera_id_;
-    StageID stage_id_;
+    StagePtr stage_;
 };
 
 class Sample: public smlt::Application {

--- a/samples/sample.cpp
+++ b/samples/sample.cpp
@@ -8,9 +8,8 @@ public:
         smlt::Scene<GameScene>(window) {}
 
     void load() {
-        auto pipeline_id = prepare_basic_scene(stage_, camera_, smlt::PARTITIONER_NULL);
-
-        window->pipeline(pipeline_id)->viewport->set_colour(smlt::Colour::SKY_BLUE);
+        auto pipeline = prepare_basic_scene(stage_, camera_, smlt::PARTITIONER_NULL);
+        pipeline->viewport->set_colour(smlt::Colour::SKY_BLUE);
 
         camera_->set_perspective_projection(
             Degrees(45.0),

--- a/samples/terrain_sample.cpp
+++ b/samples/terrain_sample.cpp
@@ -54,16 +54,16 @@ public:
             return !done;
         });
 
-        pipeline_id_ = prepare_basic_scene(stage_, camera_id_);
+        pipeline_id_ = prepare_basic_scene(stage_, camera_);
         window->disable_pipeline(pipeline_id_);
 
-        camera_id_.fetch()->set_perspective_projection(
+        camera_->set_perspective_projection(
             Degrees(45.0), float(window->width()) / float(window->height()), 10.0, 10000.0
         );
 
         window->pipeline(pipeline_id_)->viewport->set_colour(smlt::Colour::SKY_BLUE);
 
-        auto cam = stage_->camera(camera_id_);
+        auto cam = camera_;
         cam->move_to(0, 50, 700);
         cam->look_at(0, 0, 0);
 
@@ -103,7 +103,7 @@ public:
 private:
     PipelineID pipeline_id_;
     StagePtr stage_;
-    CameraID camera_id_;
+    CameraPtr camera_;
 
     MeshID terrain_mesh_id_;
     ActorPtr terrain_actor_;

--- a/samples/terrain_sample.cpp
+++ b/samples/terrain_sample.cpp
@@ -54,10 +54,8 @@ public:
             return !done;
         });
 
-        pipeline_id_ = prepare_basic_scene(stage_id_, camera_id_);
+        pipeline_id_ = prepare_basic_scene(stage_, camera_id_);
         window->disable_pipeline(pipeline_id_);
-
-        auto stage = window->stage(stage_id_);
 
         camera_id_.fetch()->set_perspective_projection(
             Degrees(45.0), float(window->width()) / float(window->height()), 10.0, 10000.0
@@ -65,31 +63,31 @@ public:
 
         window->pipeline(pipeline_id_)->viewport->set_colour(smlt::Colour::SKY_BLUE);
 
-        auto cam = stage->camera(camera_id_);
+        auto cam = stage_->camera(camera_id_);
         cam->move_to(0, 50, 700);
         cam->look_at(0, 0, 0);
 
-        terrain_material_id_ = stage->assets->new_material_from_file("sample_data/terrain_splat.kglm", GARBAGE_COLLECT_NEVER);
+        terrain_material_id_ = stage_->assets->new_material_from_file("sample_data/terrain_splat.kglm", GARBAGE_COLLECT_NEVER);
         smlt::HeightmapSpecification spec;
         spec.smooth_iterations = 0;
 
-        terrain_mesh_id_ = stage->assets->new_mesh_from_heightmap("sample_data/terrain.png", spec);
-        auto terrain_mesh = stage->assets->mesh(terrain_mesh_id_);
+        terrain_mesh_id_ = stage_->assets->new_mesh_from_heightmap("sample_data/terrain.png", spec);
+        auto terrain_mesh = stage_->assets->mesh(terrain_mesh_id_);
 
         auto terrain_data = terrain_mesh->data->get<smlt::TerrainData>("terrain_data");
-        smlt::TextureID terrain_splatmap = stage->assets->new_texture();
+        smlt::TextureID terrain_splatmap = stage_->assets->new_texture();
         calculate_splat_map(
             terrain_data.x_size,
             terrain_data.z_size,
-            stage->assets->texture(terrain_splatmap),
+            stage_->assets->texture(terrain_splatmap),
             terrain_mesh->shared_data
         );
 
-        stage->assets->material(terrain_material_id_)->first_pass()->set_texture_unit(4, terrain_splatmap);
+        stage_->assets->material(terrain_material_id_)->first_pass()->set_texture_unit(4, terrain_splatmap);
 
         terrain_mesh->set_material_id(terrain_material_id_);
 
-        terrain_actor_ = stage->new_actor_with_mesh(terrain_mesh_id_);
+        terrain_actor_ = stage_->new_actor_with_mesh(terrain_mesh_id_);
 
         done = true;
     }
@@ -104,7 +102,7 @@ public:
 
 private:
     PipelineID pipeline_id_;
-    StageID stage_id_;
+    StagePtr stage_;
     CameraID camera_id_;
 
     MeshID terrain_mesh_id_;

--- a/samples/terrain_sample.cpp
+++ b/samples/terrain_sample.cpp
@@ -99,7 +99,6 @@ public:
     }
 
     void fixed_update(float dt) override {
-        auto stage = window->stage(stage_id_);
         terrain_actor_->rotate_global_y_by(smlt::Degrees(dt * 5.0));
     }
 

--- a/samples/terrain_sample.cpp
+++ b/samples/terrain_sample.cpp
@@ -54,14 +54,14 @@ public:
             return !done;
         });
 
-        pipeline_id_ = prepare_basic_scene(stage_, camera_);
-        window->disable_pipeline(pipeline_id_);
+        pipeline_ = prepare_basic_scene(stage_, camera_);
+        pipeline_->deactivate();
 
         camera_->set_perspective_projection(
             Degrees(45.0), float(window->width()) / float(window->height()), 10.0, 10000.0
         );
 
-        window->pipeline(pipeline_id_)->viewport->set_colour(smlt::Colour::SKY_BLUE);
+        pipeline_->viewport->set_colour(smlt::Colour::SKY_BLUE);
 
         auto cam = camera_;
         cam->move_to(0, 50, 700);
@@ -93,7 +93,7 @@ public:
     }
 
     void activate() {
-        window->enable_pipeline(pipeline_id_);
+        pipeline_->activate();
     }
 
     void fixed_update(float dt) override {
@@ -101,7 +101,7 @@ public:
     }
 
 private:
-    PipelineID pipeline_id_;
+    PipelinePtr pipeline_;
     StagePtr stage_;
     CameraPtr camera_;
 

--- a/samples/terrain_sample.cpp
+++ b/samples/terrain_sample.cpp
@@ -89,7 +89,7 @@ public:
 
         terrain_mesh->set_material_id(terrain_material_id_);
 
-        terrain_actor_id_ = stage->new_actor_with_mesh(terrain_mesh_id_);
+        terrain_actor_ = stage->new_actor_with_mesh(terrain_mesh_id_);
 
         done = true;
     }
@@ -100,7 +100,7 @@ public:
 
     void fixed_update(float dt) override {
         auto stage = window->stage(stage_id_);
-        stage->actor(terrain_actor_id_)->rotate_global_y_by(smlt::Degrees(dt * 5.0));
+        terrain_actor_->rotate_global_y_by(smlt::Degrees(dt * 5.0));
     }
 
 private:
@@ -109,7 +109,7 @@ private:
     CameraID camera_id_;
 
     MeshID terrain_mesh_id_;
-    ActorID terrain_actor_id_;
+    ActorPtr terrain_actor_;
     MaterialID terrain_material_id_;
 
     TextureID terrain_textures_[4];

--- a/samples/ui_demo.cpp
+++ b/samples/ui_demo.cpp
@@ -12,7 +12,7 @@ public:
         stage_ = window->new_stage();
         camera_ = stage_->new_camera_with_orthographic_projection(0, window->width(), 0, window->height());
 
-        window->render(stage_->id(), camera_).with_clear(smlt::BUFFER_CLEAR_ALL, smlt::Colour::BLACK);
+        window->render(stage_, camera_).with_clear(smlt::BUFFER_CLEAR_ALL, smlt::Colour::BLACK);
 
         //stage_->ui->transform_input_with_camera(camera_);
 
@@ -34,7 +34,7 @@ public:
 
 private:
     smlt::StagePtr stage_;
-    smlt::CameraID camera_;
+    smlt::CameraPtr camera_;
 };
 
 class App : public smlt::Application {

--- a/samples/ui_demo.cpp
+++ b/samples/ui_demo.cpp
@@ -16,13 +16,13 @@ public:
 
         //stage_->ui->transform_input_with_camera(camera_);
 
-        auto title = stage_->ui->new_widget_as_label("UI Sample demonstrating widgets").fetch();
+        auto title = stage_->ui->new_widget_as_label("UI Sample demonstrating widgets");
         title->move_to(window->coordinate_from_normalized(0.5, 0.9));
 
-        auto button = stage_->ui->new_widget_as_button("Button 1").fetch();
+        auto button = stage_->ui->new_widget_as_button("Button 1");
         button->move_to(window->coordinate_from_normalized(0.1, 0.25));
 
-        auto pg = stage_->ui->new_widget_as_progress_bar().fetch_as<smlt::ui::ProgressBar>();
+        auto pg = stage_->ui->new_widget_as_progress_bar();
         pg->move_to(window->coordinate_from_normalized(0.5, 0.5));
         pg->resize(400, 10);
         pg->pulse();

--- a/samples/ui_demo.cpp
+++ b/samples/ui_demo.cpp
@@ -10,21 +10,19 @@ public:
 
     void load() {
         stage_ = window->new_stage();
-        camera_ = stage_.fetch()->new_camera_with_orthographic_projection(0, window->width(), 0, window->height());
+        camera_ = stage_->new_camera_with_orthographic_projection(0, window->width(), 0, window->height());
 
-        window->render(stage_, camera_).with_clear(smlt::BUFFER_CLEAR_ALL, smlt::Colour::BLACK);
+        window->render(stage_->id(), camera_).with_clear(smlt::BUFFER_CLEAR_ALL, smlt::Colour::BLACK);
 
-        smlt::StagePtr stage = stage_.fetch();
+        //stage_->ui->transform_input_with_camera(camera_);
 
-        //stage->ui->transform_input_with_camera(camera_);
-
-        auto title = stage->ui->new_widget_as_label("UI Sample demonstrating widgets").fetch();
+        auto title = stage_->ui->new_widget_as_label("UI Sample demonstrating widgets").fetch();
         title->move_to(window->coordinate_from_normalized(0.5, 0.9));
 
-        auto button = stage->ui->new_widget_as_button("Button 1").fetch();
+        auto button = stage_->ui->new_widget_as_button("Button 1").fetch();
         button->move_to(window->coordinate_from_normalized(0.1, 0.25));
 
-        auto pg = stage->ui->new_widget_as_progress_bar().fetch_as<smlt::ui::ProgressBar>();
+        auto pg = stage_->ui->new_widget_as_progress_bar().fetch_as<smlt::ui::ProgressBar>();
         pg->move_to(window->coordinate_from_normalized(0.5, 0.5));
         pg->resize(400, 10);
         pg->pulse();
@@ -35,7 +33,7 @@ public:
     }
 
 private:
-    smlt::StageID stage_;
+    smlt::StagePtr stage_;
     smlt::CameraID camera_;
 };
 

--- a/samples/viewport_sample.cpp
+++ b/samples/viewport_sample.cpp
@@ -16,9 +16,9 @@ public:
         auto stage = window->stage(sid);
 
         smlt::MeshID cube = stage->assets->new_mesh_as_cube(1.0);
-        smlt::ActorID aid = stage->new_actor_with_mesh(cube);
+        smlt::ActorPtr actor = stage->new_actor_with_mesh(cube);
 
-        stage->actor(aid)->move_to(0, 0, -5);
+        actor->move_to(0, 0, -5);
 
         // Render new stages to the framebuffer, using both viewports. Make sure we tell the pipeline to clear
         window->render(sid, stage->new_camera_for_viewport(first)).to_framebuffer(first).with_clear();

--- a/samples/viewport_sample.cpp
+++ b/samples/viewport_sample.cpp
@@ -12,8 +12,7 @@ public:
         smlt::Viewport first(smlt::VIEWPORT_TYPE_VERTICAL_SPLIT_LEFT, smlt::Colour::RED);
         smlt::Viewport second(smlt::VIEWPORT_TYPE_VERTICAL_SPLIT_RIGHT, smlt::Colour::GREEN);
 
-        smlt::StageID sid = window->new_stage();
-        auto stage = window->stage(sid);
+        auto stage = window->new_stage();
 
         smlt::MeshID cube = stage->assets->new_mesh_as_cube(1.0);
         smlt::ActorPtr actor = stage->new_actor_with_mesh(cube);
@@ -21,8 +20,8 @@ public:
         actor->move_to(0, 0, -5);
 
         // Render new stages to the framebuffer, using both viewports. Make sure we tell the pipeline to clear
-        window->render(sid, stage->new_camera_for_viewport(first)).to_framebuffer(first).with_clear();
-        window->render(sid, stage->new_camera_for_viewport(second)).to_framebuffer(second).with_clear();
+        window->render(stage->id(), stage->new_camera_for_viewport(first)).to_framebuffer(first).with_clear();
+        window->render(stage->id(), stage->new_camera_for_viewport(second)).to_framebuffer(second).with_clear();
     }
 };
 

--- a/samples/viewport_sample.cpp
+++ b/samples/viewport_sample.cpp
@@ -20,8 +20,8 @@ public:
         actor->move_to(0, 0, -5);
 
         // Render new stages to the framebuffer, using both viewports. Make sure we tell the pipeline to clear
-        window->render(stage->id(), stage->new_camera_for_viewport(first)).to_framebuffer(first).with_clear();
-        window->render(stage->id(), stage->new_camera_for_viewport(second)).to_framebuffer(second).with_clear();
+        window->render(stage, stage->new_camera_for_viewport(first)).to_framebuffer(first).with_clear();
+        window->render(stage, stage->new_camera_for_viewport(second)).to_framebuffer(second).with_clear();
     }
 };
 

--- a/simulant/backgrounds/background.cpp
+++ b/simulant/backgrounds/background.cpp
@@ -34,7 +34,7 @@ Background::Background(BackgroundID background_id, BackgroundManager *manager, B
 
 bool Background::init() {
     //Create a stage to add to the render pipeline
-    stage_ = manager_->window->new_stage(PARTITIONER_NULL).fetch();
+    stage_ = manager_->window->new_stage(PARTITIONER_NULL);
     //We need to create an orthographic camera
     camera_id_ = stage_->new_camera();
 

--- a/simulant/backgrounds/background.cpp
+++ b/simulant/backgrounds/background.cpp
@@ -21,7 +21,7 @@
 #include "../nodes/camera.h"
 
 #include "background.h"
-
+#include "../render_sequence.h"
 
 namespace smlt {
 
@@ -47,7 +47,7 @@ bool Background::init() {
     sprite_ = stage->sprites->new_sprite();
 
     //Add a pass for this background
-    pipeline_id_ = manager_->window->render(stage_, camera_).with_priority(
+    pipeline_ = manager_->window->render(stage_, camera_).with_priority(
         smlt::RENDER_PRIORITY_BACKGROUND + manager_->background_count()
     );
 
@@ -57,7 +57,7 @@ bool Background::init() {
 void Background::cleanup() {
     //Remove the pipeline and delete the stage, everything else is cleaned
     //up automatically
-    manager_->window->delete_pipeline(pipeline_id_);
+    manager_->window->delete_pipeline(pipeline_->id());
     manager_->window->delete_stage(stage_->id());
 }
 

--- a/simulant/backgrounds/background.cpp
+++ b/simulant/backgrounds/background.cpp
@@ -36,19 +36,18 @@ bool Background::init() {
     //Create a stage to add to the render pipeline
     stage_ = manager_->window->new_stage(PARTITIONER_NULL);
     //We need to create an orthographic camera
-    camera_id_ = stage_->new_camera();
+    camera_ = stage_->new_camera();
 
     // Create a unit projection
     // FIXME: allow passing a viewport and adjust accordingly
-    auto cam = camera_id_.fetch();
-    cam->set_orthographic_projection(
+    camera_->set_orthographic_projection(
         -0.5, 0.5, -0.5, 0.5
     );
 
     sprite_ = stage->sprites->new_sprite().fetch();
 
     //Add a pass for this background
-    pipeline_id_ = manager_->window->render(stage_, cam).with_priority(
+    pipeline_id_ = manager_->window->render(stage_, camera_).with_priority(
         smlt::RENDER_PRIORITY_BACKGROUND + manager_->background_count()
     );
 

--- a/simulant/backgrounds/background.cpp
+++ b/simulant/backgrounds/background.cpp
@@ -44,7 +44,7 @@ bool Background::init() {
         -0.5, 0.5, -0.5, 0.5
     );
 
-    sprite_ = stage->sprites->new_sprite().fetch();
+    sprite_ = stage->sprites->new_sprite();
 
     //Add a pass for this background
     pipeline_id_ = manager_->window->render(stage_, camera_).with_priority(

--- a/simulant/backgrounds/background.h
+++ b/simulant/backgrounds/background.h
@@ -78,7 +78,7 @@ private:
 
     BackgroundType type_;
     StagePtr stage_;
-    CameraID camera_id_;
+    CameraPtr camera_;
     PipelineID pipeline_id_;
     SpritePtr sprite_;
 

--- a/simulant/backgrounds/background.h
+++ b/simulant/backgrounds/background.h
@@ -79,7 +79,7 @@ private:
     BackgroundType type_;
     StagePtr stage_;
     CameraPtr camera_;
-    PipelineID pipeline_id_;
+    PipelinePtr pipeline_;
     SpritePtr sprite_;
 
     BackgroundResizeStyle style_ = BACKGROUND_RESIZE_ZOOM;

--- a/simulant/backgrounds/background_manager.cpp
+++ b/simulant/backgrounds/background_manager.cpp
@@ -64,8 +64,9 @@ bool BackgroundManager::has_background(BackgroundID bid) const {
     return BackgroundManager::contains(bid);
 }
 
-void BackgroundManager::delete_background(BackgroundID bid) {
+BackgroundPtr BackgroundManager::delete_background(BackgroundID bid) {
     BackgroundManager::destroy(bid);
+    return nullptr;
 }
 
 uint32_t BackgroundManager::background_count() const {

--- a/simulant/backgrounds/background_manager.cpp
+++ b/simulant/backgrounds/background_manager.cpp
@@ -26,12 +26,12 @@ void BackgroundManager::update(float dt) {
     }
 }
 
-BackgroundID BackgroundManager::new_background(BackgroundType type) {
-    return make(this, type);
+BackgroundPtr BackgroundManager::new_background(BackgroundType type) {
+    return make(this, type).fetch();
 }
 
-BackgroundID BackgroundManager::new_background_as_scrollable_from_file(const unicode& filename, float scroll_x, float scroll_y) {
-    BackgroundPtr bg = new_background(BACKGROUND_TYPE_SCROLL).fetch();
+BackgroundPtr BackgroundManager::new_background_as_scrollable_from_file(const unicode& filename, float scroll_x, float scroll_y) {
+    BackgroundPtr bg = new_background(BACKGROUND_TYPE_SCROLL);
     try {
         bg->set_texture(window_->shared_assets->new_texture_from_file(filename));
         bg->set_horizontal_scroll_rate(scroll_x);
@@ -41,11 +41,11 @@ BackgroundID BackgroundManager::new_background_as_scrollable_from_file(const uni
         throw;
     }
 
-    return bg->id();
+    return bg;
 }
 
-BackgroundID BackgroundManager::new_background_as_animated_from_file(const unicode& filename) {
-    BackgroundPtr bg = new_background(BACKGROUND_TYPE_ANIMATED).fetch();
+BackgroundPtr BackgroundManager::new_background_as_animated_from_file(const unicode& filename) {
+    BackgroundPtr bg = new_background(BACKGROUND_TYPE_ANIMATED);
     try {
         bg->set_texture(window_->shared_assets->new_texture_from_file(filename));
     } catch(...) {
@@ -53,7 +53,7 @@ BackgroundID BackgroundManager::new_background_as_animated_from_file(const unico
         throw;
     }
 
-    return bg->id();
+    return bg;
 }
 
 BackgroundPtr BackgroundManager::background(BackgroundID bid) {

--- a/simulant/backgrounds/background_manager.h
+++ b/simulant/backgrounds/background_manager.h
@@ -15,9 +15,9 @@ public:
     BackgroundManager(Window* window);
     ~BackgroundManager();
 
-    BackgroundID new_background(BackgroundType type);
-    BackgroundID new_background_as_scrollable_from_file(const unicode& filename, float scroll_x=0.0, float scroll_y=0.0);
-    BackgroundID new_background_as_animated_from_file(const unicode& filename);
+    BackgroundPtr new_background(BackgroundType type);
+    BackgroundPtr new_background_as_scrollable_from_file(const unicode& filename, float scroll_x=0.0, float scroll_y=0.0);
+    BackgroundPtr new_background_as_animated_from_file(const unicode& filename);
 
     BackgroundPtr background(BackgroundID bid);
     bool has_background(BackgroundID bid) const;

--- a/simulant/backgrounds/background_manager.h
+++ b/simulant/backgrounds/background_manager.h
@@ -21,7 +21,7 @@ public:
 
     BackgroundPtr background(BackgroundID bid);
     bool has_background(BackgroundID bid) const;
-    void delete_background(BackgroundID bid);
+    BackgroundPtr delete_background(BackgroundID bid);
     uint32_t background_count() const;
 
     void delete_all_backgrounds();

--- a/simulant/debug.h
+++ b/simulant/debug.h
@@ -77,7 +77,7 @@ private:
     std::vector<DebugElement> elements_;
 
     MeshID mesh_;
-    ActorPtr actor_;
+    ActorPtr actor_ = nullptr;
     MaterialID material_;
 
     sig::Connection update_connection_;

--- a/simulant/debug.h
+++ b/simulant/debug.h
@@ -77,7 +77,7 @@ private:
     std::vector<DebugElement> elements_;
 
     MeshID mesh_;
-    ActorID actor_;
+    ActorPtr actor_;
     MaterialID material_;
 
     sig::Connection update_connection_;

--- a/simulant/generic/manager.h
+++ b/simulant/generic/manager.h
@@ -41,7 +41,9 @@ private:
     template<typename Q=ObjectIDType>
     typename ObjectIDType::resource_pointer_type getter(
             const ObjectIDType* id,
-            typename std::enable_if<std::is_pointer<typename Q::resource_pointer_type>::value>::type* = 0) {
+            typename std::enable_if<
+                std::is_convertible<typename Q::resource_pointer_type, ObjectType*>::value
+            >::type* = 0) {
         return get(*id).lock().get();
     }
 
@@ -49,7 +51,9 @@ private:
     template<typename Q=ObjectIDType>
     typename ObjectIDType::resource_pointer_type getter(
             const ObjectIDType* id,
-            typename std::enable_if<!std::is_pointer<typename Q::resource_pointer_type>::value>::type* = 0) {
+            typename std::enable_if<
+                !std::is_convertible<typename Q::resource_pointer_type, ObjectType*>::value
+            >::type* = 0) {
         return get(*id).lock();
     }
 

--- a/simulant/generic/unique_id.h
+++ b/simulant/generic/unique_id.h
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <functional>
 
+
 template<typename ResourceTypePtr>
 class UniqueID {
 public:
@@ -50,7 +51,8 @@ public:
 
     template<typename T>
     T* fetch_as() const {
-        return dynamic_cast<T*>(fetch());
+        /* The weird &(* casting is to handle smart pointers */
+        return dynamic_cast<T*>(&(*fetch()));
     }
 
     bool is_bound() const {

--- a/simulant/managers.cpp
+++ b/simulant/managers.cpp
@@ -108,13 +108,13 @@ StageManager::StageManager(Window* window):
 
 }
 
-StageID StageManager::new_stage(AvailablePartitioner partitioner) {
+StagePtr StageManager::new_stage(AvailablePartitioner partitioner) {
     auto ret = StageManager::make(this->window_, partitioner);
     signal_stage_added_(ret);
-    return ret;
+    return ret.fetch();
 }
 
-uint32_t StageManager::stage_count() const {
+std::size_t StageManager::stage_count() const {
     return StageManager::count();
 }
 

--- a/simulant/managers.cpp
+++ b/simulant/managers.cpp
@@ -131,9 +131,10 @@ StagePtr StageManager::stage(StageID s) {
     return StageManager::get(s).lock().get();
 }
 
-void StageManager::delete_stage(StageID s) {
+StagePtr StageManager::delete_stage(StageID s) {
     StageManager::destroy(s);
     signal_stage_removed_(s);
+    return nullptr;
 }
 
 void StageManager::fixed_update(float dt) {

--- a/simulant/managers.cpp
+++ b/simulant/managers.cpp
@@ -37,19 +37,19 @@ CameraManager::CameraManager(Stage *stage):
 
 }
 
-CameraID CameraManager::new_camera() {
-    CameraID new_camera = cameras_.make(this->stage_);
-    new_camera.fetch()->set_parent(stage_);
+CameraPtr CameraManager::new_camera() {
+    auto new_camera = cameras_.make(this->stage_).fetch();
+    new_camera->set_parent(stage_);
 
     return new_camera;
 }
 
-CameraID CameraManager::new_camera_with_orthographic_projection(double left, double right, double bottom, double top, double near, double far) {
+CameraPtr CameraManager::new_camera_with_orthographic_projection(double left, double right, double bottom, double top, double near, double far) {
     /*
      *  Instantiates a camera with an orthographic projection. If both left and right are zero then they default to 0 and window.width()
      *  respectively. If top and bottom are zero, then they default to window.height() and 0 respectively. So top left is 0,0
      */
-    CameraID new_camera_id = new_camera();
+    auto new_cam = new_camera();
 
     if(!left && !right) {
         right = stage_->window->width();
@@ -59,22 +59,22 @@ CameraID CameraManager::new_camera_with_orthographic_projection(double left, dou
         top = stage_->window->height();
     }
 
-    camera(new_camera_id)->set_orthographic_projection(left, right, bottom, top, near, far);
+    new_cam->set_orthographic_projection(left, right, bottom, top, near, far);
 
-    return new_camera_id;
+    return new_cam;
 }
 
-CameraID CameraManager::new_camera_for_viewport(const Viewport& vp) {
+CameraPtr CameraManager::new_camera_for_viewport(const Viewport& vp) {
     float x, y, width, height;
     calculate_ratios_from_viewport(vp.type(), x, y, width, height);
 
-    CameraID cid = new_camera();
-    camera(cid)->set_perspective_projection(Degrees(45.0), width / height);
+    auto camera = new_camera();
+    camera->set_perspective_projection(Degrees(45.0), width / height);
 
-    return cid;
+    return camera;
 }
 
-CameraID CameraManager::new_camera_for_ui() {
+CameraPtr CameraManager::new_camera_for_ui() {
     return new_camera_with_orthographic_projection(0, stage_->window->width(), 0, stage_->window->height(), -1, 1);
 }
 

--- a/simulant/managers.h
+++ b/simulant/managers.h
@@ -35,10 +35,10 @@ class CameraManager {
 public:
     CameraManager(Stage* stage);
 
-    CameraID new_camera();
-    CameraID new_camera_with_orthographic_projection(double left=0, double right=0, double bottom=0, double top=0, double near=-1.0, double far=1.0);
-    CameraID new_camera_for_ui();
-    CameraID new_camera_for_viewport(const Viewport& vp);
+    CameraPtr new_camera();
+    CameraPtr new_camera_with_orthographic_projection(double left=0, double right=0, double bottom=0, double top=0, double near=-1.0, double far=1.0);
+    CameraPtr new_camera_for_ui();
+    CameraPtr new_camera_for_viewport(const Viewport& vp);
     CameraPtr camera(CameraID c);
     void delete_camera(CameraID cid);
     uint32_t camera_count() const;

--- a/simulant/managers.h
+++ b/simulant/managers.h
@@ -64,10 +64,10 @@ class StageManager:
 public:
     StageManager(Window* window);
 
-    StageID new_stage(AvailablePartitioner partitioner=PARTITIONER_HASH);
+    StagePtr new_stage(AvailablePartitioner partitioner=PARTITIONER_HASH);
     StagePtr stage(StageID s);
     void delete_stage(StageID s);
-    uint32_t stage_count() const;
+    std::size_t stage_count() const;
     bool has_stage(StageID stage_id) const;
 
     void print_tree();

--- a/simulant/managers.h
+++ b/simulant/managers.h
@@ -66,7 +66,7 @@ public:
 
     StagePtr new_stage(AvailablePartitioner partitioner=PARTITIONER_HASH);
     StagePtr stage(StageID s);
-    void delete_stage(StageID s);
+    StagePtr delete_stage(StageID s);
     std::size_t stage_count() const;
     bool has_stage(StageID stage_id) const;
 

--- a/simulant/managers/skybox_manager.cpp
+++ b/simulant/managers/skybox_manager.cpp
@@ -119,7 +119,7 @@ SkyManager::SkyManager(Window* window, Stage* stage):
  * in their names. If duplicates are found, or if images are not found, then this function raises
  * SkyboxImageNotFoundError or SkyboxImageDuplicateError respectively
  */
-SkyID SkyManager::new_skybox_from_folder(const unicode& folder) {
+SkyboxPtr SkyManager::new_skybox_from_folder(const unicode& folder) {
     std::map<SkyboxFace, std::string> files;
 
     auto path = window->resource_locator->locate_file(folder);
@@ -191,7 +191,7 @@ SkyID SkyManager::new_skybox_from_folder(const unicode& folder) {
  * Creates a skybox with the 6 images specified. If any of the images are not found this throws a
  * SkyboxImageNotFoundError
  */
-SkyID SkyManager::new_skybox_from_files(
+SkyboxPtr SkyManager::new_skybox_from_files(
     const unicode& up,
     const unicode& down,
     const unicode& left,
@@ -208,7 +208,7 @@ SkyID SkyManager::new_skybox_from_files(
         up, down, left, right, front, back
     );
 
-    return sid;
+    return sb;
 }
 
 SkyboxPtr SkyManager::skybox(SkyID skybox_id) {

--- a/simulant/managers/skybox_manager.cpp
+++ b/simulant/managers/skybox_manager.cpp
@@ -46,7 +46,9 @@ void Skybox::ask_owner_for_destruction() {
     manager_->delete_skybox(id());
 }
 
-const AABB &Skybox::aabb() const { return actor_id_.fetch()->aabb(); }
+const AABB &Skybox::aabb() const {
+    return actor_->aabb();
+}
 
 void Skybox::generate(
         const unicode& up,
@@ -58,10 +60,10 @@ void Skybox::generate(
 ) {
     auto stage = manager_->stage.get();
 
-    if(!actor_id_) {
-        actor_id_ = stage->new_actor();
-        actor_id_.fetch()->set_parent(this);
-        actor_id_.fetch()->move_to(0, 0, 0);
+    if(!actor_) {
+        actor_ = stage->new_actor();
+        actor_->set_parent(this);
+        actor_->move_to(0, 0, 0);
     }
 
     if(!mesh_id_) {
@@ -95,13 +97,10 @@ void Skybox::generate(
         mesh->submesh("back")->set_texture_on_material(0, stage->assets->new_texture_from_file(back_path, flags));
     }
 
-    {
-        auto actor = stage->actor(actor_id_);
-        actor->set_mesh(mesh_id_);
-        actor->set_render_priority(smlt::RENDER_PRIORITY_ABSOLUTE_BACKGROUND);
-        actor->lock_rotation();
-        actor->set_renderable_culling_mode(RENDERABLE_CULLING_MODE_NEVER);
-    }
+    actor_->set_mesh(mesh_id_);
+    actor_->set_render_priority(smlt::RENDER_PRIORITY_ABSOLUTE_BACKGROUND);
+    actor_->lock_rotation();
+    actor_->set_renderable_culling_mode(RENDERABLE_CULLING_MODE_NEVER);
 }
 
 

--- a/simulant/managers/skybox_manager.h
+++ b/simulant/managers/skybox_manager.h
@@ -112,8 +112,8 @@ public:
     SkyManager(const SkyManager& rhs) = delete;
     SkyManager& operator=(const SkyManager&) = delete;
 
-    SkyID new_skybox_from_folder(const unicode& folder);
-    SkyID new_skybox_from_files(
+    SkyboxPtr new_skybox_from_folder(const unicode& folder);
+    SkyboxPtr new_skybox_from_files(
         const unicode& up,
         const unicode& down,
         const unicode& left,

--- a/simulant/managers/skybox_manager.h
+++ b/simulant/managers/skybox_manager.h
@@ -78,7 +78,7 @@ private:
 
     CameraID follow_camera_;
 
-    ActorPtr actor_;
+    ActorPtr actor_ = nullptr;
     MeshID mesh_id_;
 
     MaterialID materials_[SKYBOX_FACE_MAX];

--- a/simulant/managers/skybox_manager.h
+++ b/simulant/managers/skybox_manager.h
@@ -78,7 +78,7 @@ private:
 
     CameraID follow_camera_;
 
-    ActorID actor_id_;
+    ActorPtr actor_;
     MeshID mesh_id_;
 
     MaterialID materials_[SKYBOX_FACE_MAX];

--- a/simulant/managers/sprite_manager.cpp
+++ b/simulant/managers/sprite_manager.cpp
@@ -15,14 +15,14 @@ void SpriteManager::delete_all() {
     objects_.clear();
 }
 
-SpriteID SpriteManager::new_sprite() {
-    SpriteID s = TemplatedSpriteManager::make(this, window->_sound_driver());
-    sprite(s)->set_parent(stage_->id());
-    signal_sprite_created_(s);
+SpritePtr SpriteManager::new_sprite() {
+    auto s = TemplatedSpriteManager::make(this, window->_sound_driver()).fetch();
+    s->set_parent(stage_->id());
+    signal_sprite_created_(s->id());
     return s;
 }
 
-SpriteID SpriteManager::new_sprite_from_file(const unicode &filename, uint32_t frame_Width, uint32_t frame_height, const SpritesheetAttrs& attrs) {
+SpritePtr SpriteManager::new_sprite_from_file(const unicode &filename, uint32_t frame_Width, uint32_t frame_height, const SpritesheetAttrs& attrs) {
     TextureID t = stage_->assets->new_texture_from_file(
         filename,
         TextureFlags(MIPMAP_GENERATE_NONE, TEXTURE_WRAP_CLAMP_TO_EDGE, TEXTURE_FILTER_POINT)
@@ -31,8 +31,8 @@ SpriteID SpriteManager::new_sprite_from_file(const unicode &filename, uint32_t f
     return new_sprite_from_texture(t, frame_Width, frame_height, attrs);
 }
 
-SpriteID SpriteManager::new_sprite_from_texture(TextureID texture_id, uint32_t frame_width, uint32_t frame_height, const SpritesheetAttrs& attrs) {
-    SpritePtr s = new_sprite().fetch();
+SpritePtr SpriteManager::new_sprite_from_texture(TextureID texture_id, uint32_t frame_width, uint32_t frame_height, const SpritesheetAttrs& attrs) {
+    SpritePtr s = new_sprite();
 
     try {
         s->set_spritesheet(texture_id, frame_width, frame_height, attrs);
@@ -44,7 +44,7 @@ SpriteID SpriteManager::new_sprite_from_texture(TextureID texture_id, uint32_t f
         throw;
     }
 
-    return s->id();
+    return s;
 }
 
 SpritePtr SpriteManager::sprite(SpriteID s) {

--- a/simulant/managers/sprite_manager.cpp
+++ b/simulant/managers/sprite_manager.cpp
@@ -55,11 +55,12 @@ bool SpriteManager::has_sprite(SpriteID s) const {
     return TemplatedSpriteManager::contains(s);
 }
 
-void SpriteManager::delete_sprite(SpriteID s) {
+SpritePtr SpriteManager::delete_sprite(SpriteID s) {
     TemplatedSpriteManager::destroy(s);
+    return nullptr;
 }
 
-uint32_t SpriteManager::sprite_count() const {
+std::size_t SpriteManager::sprite_count() const {
     return TemplatedSpriteManager::count();
 }
 

--- a/simulant/managers/sprite_manager.h
+++ b/simulant/managers/sprite_manager.h
@@ -36,8 +36,8 @@ public:
 
     SpritePtr sprite(SpriteID s);
     bool has_sprite(SpriteID s) const;
-    void delete_sprite(SpriteID s);
-    uint32_t sprite_count() const;
+    SpritePtr delete_sprite(SpriteID s);
+    std::size_t sprite_count() const;
     void delete_all();
 
     Property<SpriteManager, Stage> stage = { this, &SpriteManager::stage_ };

--- a/simulant/managers/sprite_manager.h
+++ b/simulant/managers/sprite_manager.h
@@ -22,14 +22,14 @@ class SpriteManager :
 public:
     SpriteManager(Window* window, Stage* stage);
 
-    SpriteID new_sprite();
-    SpriteID new_sprite_from_file(
+    SpritePtr new_sprite();
+    SpritePtr new_sprite_from_file(
         const unicode& filename,
         uint32_t frame_width, uint32_t frame_height,
         const SpritesheetAttrs &attrs=SpritesheetAttrs()
     );
 
-    SpriteID new_sprite_from_texture(TextureID texture_id,
+    SpritePtr new_sprite_from_texture(TextureID texture_id,
         uint32_t frame_width, uint32_t frame_height,
         const SpritesheetAttrs &attrs=SpritesheetAttrs()
     );

--- a/simulant/meshes/adjacency_info.cpp
+++ b/simulant/meshes/adjacency_info.cpp
@@ -43,6 +43,10 @@ void AdjacencyInfo::rebuild() {
 
         submesh->each_triangle([&](uint32_t a, uint32_t b, uint32_t c) {
             // FIXME: What if it's a vec2?
+            assert(a < mesh_->shared_data->count());
+            assert(b < mesh_->shared_data->count());
+            assert(c < mesh_->shared_data->count());
+
             auto v1 = to_tuple(mesh_->shared_data->position_at<smlt::Vec3>(a));
             auto v2 = to_tuple(mesh_->shared_data->position_at<smlt::Vec3>(b));
             auto v3 = to_tuple(mesh_->shared_data->position_at<smlt::Vec3>(c));

--- a/simulant/nodes/sprite.cpp
+++ b/simulant/nodes/sprite.cpp
@@ -42,8 +42,8 @@ bool Sprite::init() {
 
     //Annoyingly, we can't use new_actor_with_parent_and_mesh here, because that looks
     //up our ID in the stage, which doesn't exist until this function returns
-    actor_id_ = stage->new_actor_with_mesh(mesh_id_);
-    actor_id_.fetch()->set_parent(this);
+    actor_ = stage->new_actor_with_mesh(mesh_id_);
+    actor_->set_parent(this);
 
     set_render_dimensions(1.0f, 1.0f);
 
@@ -57,9 +57,9 @@ bool Sprite::init() {
 }
 
 void Sprite::cleanup() {
-    if(actor_id_ && stage->has_actor(actor_id_)) {
-        stage->delete_actor(actor_id_);
-        actor_id_ = smlt::ActorID(0);
+    if(actor_ && stage->has_actor(actor_->id())) {
+        stage->delete_actor(actor_->id());
+        actor_ = nullptr;
     }
 }
 
@@ -68,8 +68,8 @@ void Sprite::ask_owner_for_destruction() {
 }
 
 void Sprite::update(float dt) {
-    if(actor_id_) {
-        stage->actor(actor_id_)->set_parent(this); //Make sure every frame that our actor stays attached to us!
+    if(actor_) {
+        actor_->set_parent(this); //Make sure every frame that our actor stays attached to us!
     }
 
     // Update any keyframe animations
@@ -84,7 +84,9 @@ void Sprite::flip_horizontally(bool value) {
     update_texture_coordinates();
 }
 
-const AABB& Sprite::aabb() const { return actor_id_.fetch()->aabb(); }
+const AABB& Sprite::aabb() const {
+    return actor_->aabb();
+}
 
 void Sprite::flip_vertically(bool value) {
     if(value == flipped_vertically_) return;
@@ -166,7 +168,7 @@ void Sprite::set_render_dimensions_from_height(float height) {
 }
 
 void Sprite::set_render_priority(RenderPriority priority) {
-    actor_id_.fetch()->set_render_priority(priority);
+    actor_->set_render_priority(priority);
 }
 
 void Sprite::set_alpha(float alpha) {

--- a/simulant/nodes/sprite.h
+++ b/simulant/nodes/sprite.h
@@ -93,7 +93,8 @@ private:
     std::pair<uint32_t, uint32_t> sprite_sheet_padding_;
     float render_width_ = 1.0;
     float render_height_ = 1.0;
-    ActorPtr actor_;
+
+    ActorPtr actor_ = nullptr;
     MeshID mesh_id_;
     MaterialID material_id_;
 

--- a/simulant/nodes/sprite.h
+++ b/simulant/nodes/sprite.h
@@ -79,10 +79,9 @@ public:
     void flip_vertically(bool value=true);
     void flip_horizontally(bool value=true);
 
-    smlt::ActorID actor_id() const { return actor_id_; }
-
     const AABB& aabb() const override;
 
+    Property<Sprite, Actor> actor = {this, &Sprite::actor_};
     Property<Sprite, KeyFrameAnimationState> animations = {this, &Sprite::animation_state_};
 private:
     SpriteManager* manager_;
@@ -94,7 +93,7 @@ private:
     std::pair<uint32_t, uint32_t> sprite_sheet_padding_;
     float render_width_ = 1.0;
     float render_height_ = 1.0;
-    ActorID actor_id_;
+    ActorPtr actor_;
     MeshID mesh_id_;
     MaterialID material_id_;
 

--- a/simulant/nodes/ui/ui_manager.cpp
+++ b/simulant/nodes/ui/ui_manager.cpp
@@ -52,34 +52,34 @@ UIManager::~UIManager() {
     window_->unregister_event_listener(this);
 }
 
-WidgetID UIManager::new_widget_as_button(const unicode &text, float width, float height) {
-    auto button = manager_->make_as<Button>(this, &config_).fetch();
+Button* UIManager::new_widget_as_button(const unicode &text, float width, float height) {
+    auto button = manager_->make_as<Button>(this, &config_).fetch_as<Button>();
     button->set_text(text);
     button->resize(width, height);
     stage_->add_child(button);
 
-    return button->id();
+    return button;
 }
 
-WidgetID UIManager::new_widget_as_label(const unicode &text, float width, float height) {
-    auto label = manager_->make_as<Label>(this, &config_).fetch();
+Label* UIManager::new_widget_as_label(const unicode &text, float width, float height) {
+    auto label = manager_->make_as<Label>(this, &config_).fetch_as<Label>();
     label->set_text(text);
     label->resize(width, height);
 
     stage_->add_child(label);
 
-    return label->id();
+    return label;
 }
 
-WidgetID UIManager::new_widget_as_progress_bar(float min, float max, float value) {
-    auto pg = manager_->make_as<ProgressBar>(this, &config_).fetch();
+ProgressBar* UIManager::new_widget_as_progress_bar(float min, float max, float value) {
+    auto pg = manager_->make_as<ProgressBar>(this, &config_).fetch_as<ProgressBar>();
     pg->set_property("min", min);
     pg->set_property("max", max);
     pg->set_property("value", value);
 
     stage_->add_child(pg);
 
-    return pg->id();
+    return pg;
 }
 
 void UIManager::delete_widget(WidgetID widget) {

--- a/simulant/nodes/ui/ui_manager.h
+++ b/simulant/nodes/ui/ui_manager.h
@@ -10,6 +10,9 @@
 namespace smlt {
 namespace ui {
 
+class Button;
+class Label;
+class ProgressBar;
 
 typedef generic::TemplatedManager<Widget, WidgetID> WidgetManager;
 
@@ -36,10 +39,9 @@ public:
     UIManager(Stage* stage);
     ~UIManager();
 
-    WidgetID new_widget_as_button(const unicode& text, float width=.0f, float height=.0f);
-
-    WidgetID new_widget_as_label(const unicode& text, float width=.0f, float height=.0f);
-    WidgetID new_widget_as_progress_bar(float min=.0f, float max=100.0f, float value=.0f);
+    Button* new_widget_as_button(const unicode& text, float width=.0f, float height=.0f);
+    Label* new_widget_as_label(const unicode& text, float width=.0f, float height=.0f);
+    ProgressBar* new_widget_as_progress_bar(float min=.0f, float max=100.0f, float value=.0f);
 
     void delete_widget(WidgetID widget);
 

--- a/simulant/nodes/ui/widget.cpp
+++ b/simulant/nodes/ui/widget.cpp
@@ -28,7 +28,7 @@ Widget::~Widget() {
 
 bool Widget::init() {
     actor_ = stage->new_actor();
-    actor_.fetch()->set_parent(this);
+    actor_->set_parent(this);
 
     material_ = stage->assets->new_material_from_file(Material::BuiltIns::DIFFUSE_ONLY).fetch();
     material_->first_pass()->set_blending(BLEND_ALPHA);
@@ -72,7 +72,7 @@ void Widget::rebuild() {
     if(!is_initialized()) return;
 
     mesh_ = construct_widget(width_, height_).fetch();
-    actor_.fetch()->set_mesh(mesh_->id());
+    actor_->set_mesh(mesh_->id());
 }
 
 void Widget::set_border_width(float x) {
@@ -113,7 +113,7 @@ void Widget::ask_owner_for_destruction() {
 }
 
 const AABB &Widget::aabb() const {
-    return actor_.fetch()->aabb();
+    return actor_->aabb();
 }
 
 void Widget::set_background_colour(const Colour& colour) {

--- a/simulant/nodes/ui/widget.h
+++ b/simulant/nodes/ui/widget.h
@@ -193,11 +193,11 @@ public:
 
 private:
     bool initialized_ = false;
-    UIManager* owner_;
-    ActorPtr actor_;
-    MeshPtr mesh_;
-    FontPtr font_;
-    MaterialPtr material_;
+    UIManager* owner_ = nullptr;
+    ActorPtr actor_ = nullptr;
+    MeshPtr mesh_ = nullptr;
+    FontPtr font_ = nullptr;
+    MaterialPtr material_ = nullptr;
 
     virtual MeshID construct_widget(float requested_width, float requested_height);
 

--- a/simulant/nodes/ui/widget.h
+++ b/simulant/nodes/ui/widget.h
@@ -194,7 +194,7 @@ public:
 private:
     bool initialized_ = false;
     UIManager* owner_;
-    ActorID actor_;
+    ActorPtr actor_;
     MeshPtr mesh_;
     FontPtr font_;
     MaterialPtr material_;

--- a/simulant/panels/partitioner_panel.cpp
+++ b/simulant/panels/partitioner_panel.cpp
@@ -38,13 +38,13 @@ void PartitionerPanel::do_activate() {
     initialize();
 
     for(auto& pair: debug_actors_) {
-        window_->stage(pair.first)->actor(pair.second)->set_visible(true);
+        pair.second->set_visible(true);
     }
 }
 
 void PartitionerPanel::do_deactivate() {
     for(auto& pair: debug_actors_) {
-        window_->stage(pair.first)->actor(pair.second)->set_visible(false);
+        pair.second->set_visible(false);
     }
 }
 

--- a/simulant/panels/partitioner_panel.h
+++ b/simulant/panels/partitioner_panel.h
@@ -38,7 +38,7 @@ private:
     void initialize();
     bool initialized_ = false;
 
-    std::unordered_map<StageID, ActorID> debug_actors_;
+    std::unordered_map<StageID, ActorPtr> debug_actors_;
 };
 
 }

--- a/simulant/panels/stats_panel.cpp
+++ b/simulant/panels/stats_panel.cpp
@@ -22,6 +22,7 @@
 #include "../stage.h"
 #include "../nodes/ui/ui_manager.h"
 #include "../render_sequence.h"
+#include "../nodes/ui/label.h"
 
 namespace smlt {
 
@@ -44,19 +45,19 @@ void StatsPanel::initialize() {
     float vheight = 460;
     const float diff = 32;
 
-    auto heading1 = overlay->ui->new_widget_as_label("Performance").fetch();
+    auto heading1 = overlay->ui->new_widget_as_label("Performance");
     heading1->move_to(320, vheight);
     vheight -= diff;
 
-    fps_ = overlay->ui->new_widget_as_label("FPS: 0").fetch();
+    fps_ = overlay->ui->new_widget_as_label("FPS: 0");
     fps_->move_to(320, vheight);
     vheight -= diff;
 
-    ram_usage_ = overlay->ui->new_widget_as_label("RAM: 0").fetch();
+    ram_usage_ = overlay->ui->new_widget_as_label("RAM: 0");
     ram_usage_->move_to(320, vheight);
     vheight -= diff;
 
-    actors_rendered_ = overlay->ui->new_widget_as_label("Renderables visible: 0").fetch();
+    actors_rendered_ = overlay->ui->new_widget_as_label("Renderables visible: 0");
     actors_rendered_->move_to(320, vheight);
     vheight -= diff;
 

--- a/simulant/panels/stats_panel.cpp
+++ b/simulant/panels/stats_panel.cpp
@@ -35,7 +35,7 @@ void StatsPanel::initialize() {
     stage_ = window_->new_stage();
 
     ui_camera_ = stage_->new_camera_with_orthographic_projection(0, 640, 0, 480);
-    pipeline_id_ = window_->render(stage_, ui_camera_.fetch()).with_priority(smlt::RENDER_PRIORITY_ABSOLUTE_FOREGROUND);
+    pipeline_id_ = window_->render(stage_, ui_camera_).with_priority(smlt::RENDER_PRIORITY_ABSOLUTE_FOREGROUND);
     window_->disable_pipeline(pipeline_id_);
 
     auto overlay = stage_;

--- a/simulant/panels/stats_panel.cpp
+++ b/simulant/panels/stats_panel.cpp
@@ -32,14 +32,13 @@ StatsPanel::StatsPanel(Window *window):
 void StatsPanel::initialize() {
     if(initialized_) return;
 
-    stage_id_ = window_->new_stage();
-    auto stage = stage_id_.fetch();
+    stage_ = window_->new_stage();
 
-    ui_camera_ = stage->new_camera_with_orthographic_projection(0, 640, 0, 480);
-    pipeline_id_ = window_->render(stage_id_, ui_camera_).with_priority(smlt::RENDER_PRIORITY_ABSOLUTE_FOREGROUND);
+    ui_camera_ = stage_->new_camera_with_orthographic_projection(0, 640, 0, 480);
+    pipeline_id_ = window_->render(stage_, ui_camera_.fetch()).with_priority(smlt::RENDER_PRIORITY_ABSOLUTE_FOREGROUND);
     window_->disable_pipeline(pipeline_id_);
 
-    auto overlay = stage_id_.fetch();
+    auto overlay = stage_;
 
     float vheight = 460;
     const float diff = 32;

--- a/simulant/panels/stats_panel.cpp
+++ b/simulant/panels/stats_panel.cpp
@@ -21,6 +21,7 @@
 #include "../window.h"
 #include "../stage.h"
 #include "../nodes/ui/ui_manager.h"
+#include "../render_sequence.h"
 
 namespace smlt {
 
@@ -35,8 +36,8 @@ void StatsPanel::initialize() {
     stage_ = window_->new_stage();
 
     ui_camera_ = stage_->new_camera_with_orthographic_projection(0, 640, 0, 480);
-    pipeline_id_ = window_->render(stage_, ui_camera_).with_priority(smlt::RENDER_PRIORITY_ABSOLUTE_FOREGROUND);
-    window_->disable_pipeline(pipeline_id_);
+    pipeline_ = window_->render(stage_, ui_camera_).with_priority(smlt::RENDER_PRIORITY_ABSOLUTE_FOREGROUND);
+    pipeline_->deactivate();
 
     auto overlay = stage_;
 
@@ -124,12 +125,12 @@ void StatsPanel::update() {
 void StatsPanel::do_activate() {
     initialize();
 
-    window_->enable_pipeline(pipeline_id_);
+    pipeline_->activate();
     L_DEBUG("Activating stats panel");
 }
 
 void StatsPanel::do_deactivate() {
-    window_->disable_pipeline(pipeline_id_);
+    pipeline_->deactivate();
     L_DEBUG("Deactivating stats panel");
 }
 

--- a/simulant/panels/stats_panel.h
+++ b/simulant/panels/stats_panel.h
@@ -39,7 +39,7 @@ private:
 
     StagePtr stage_;
     CameraPtr ui_camera_;
-    PipelineID pipeline_id_;
+    PipelinePtr pipeline_;
 
     void update();
 

--- a/simulant/panels/stats_panel.h
+++ b/simulant/panels/stats_panel.h
@@ -38,7 +38,7 @@ private:
     bool initialized_ = false;
 
     StagePtr stage_;
-    CameraID ui_camera_;
+    CameraPtr ui_camera_;
     PipelineID pipeline_id_;
 
     void update();

--- a/simulant/panels/stats_panel.h
+++ b/simulant/panels/stats_panel.h
@@ -37,7 +37,7 @@ private:
     void initialize();
     bool initialized_ = false;
 
-    StageID stage_id_;
+    StagePtr stage_;
     CameraID ui_camera_;
     PipelineID pipeline_id_;
 

--- a/simulant/pipeline_helper.cpp
+++ b/simulant/pipeline_helper.cpp
@@ -23,31 +23,31 @@
 namespace smlt {
 
 PipelineHelper PipelineHelper::to_framebuffer(const Viewport &view) {
-    sequence_->pipeline(pipeline_id_)->set_viewport(view);
-    sequence_->pipeline(pipeline_id_)->set_target(TextureID());
+    pipeline_->set_viewport(view);
+    pipeline_->set_target(TextureID());
     return *this;
 }
 
 PipelineHelper PipelineHelper::to_texture(TextureID tex, const Viewport& view) {
-    sequence_->pipeline(pipeline_id_)->set_target(tex);
-    sequence_->pipeline(pipeline_id_)->set_viewport(view);
+    pipeline_->set_target(tex);
+    pipeline_->set_viewport(view);
     return *this;
 }
 
 PipelineHelper PipelineHelper::with_clear(uint32_t viewport_clear_flags, const smlt::Colour& clear_colour) {
-    sequence_->pipeline(pipeline_id_)->set_clear_flags(viewport_clear_flags);
-    sequence_->pipeline(pipeline_id_)->viewport->set_colour(clear_colour);
+    pipeline_->set_clear_flags(viewport_clear_flags);
+    pipeline_->viewport->set_colour(clear_colour);
     return *this;
 }
 
 PipelineHelper PipelineHelper::with_priority(smlt::RenderPriority priority) {
-    sequence_->pipeline(pipeline_id_)->set_priority((int) priority);
+    pipeline_->set_priority((int) priority);
     return *this;
 }
 
 
 PipelineHelper PipelineHelperAPIInterface::new_pipeline_helper(RenderSequence::ptr sequence, StageID stage, CameraID cam) {
-    PipelineID pid = sequence->new_pipeline(stage, cam);
+    PipelinePtr pid = sequence->new_pipeline(stage, cam);
     return PipelineHelper(sequence, pid);
 }
 

--- a/simulant/pipeline_helper.h
+++ b/simulant/pipeline_helper.h
@@ -37,13 +37,8 @@ public:
     PipelineHelper(const PipelineHelper&) = default;
     PipelineHelper& operator=(const PipelineHelper& rhs) = default;
 
-    operator PipelineID() const {
-        return pipeline_id_;
-    }
-
-    // This allows grabbing the pipeline directly after creation
-    PipelinePtr fetch() const {
-        return pipeline_id_.fetch();
+    operator PipelinePtr() const {
+        return pipeline_;
     }
 
 private:
@@ -51,11 +46,11 @@ private:
 
     typedef std::shared_ptr<RenderSequence> RenderSequencePtr;
 
-    PipelineHelper(RenderSequencePtr sequence, PipelineID pid):
-        sequence_(sequence), pipeline_id_(pid) {}
+    PipelineHelper(RenderSequencePtr sequence, PipelinePtr pid):
+        sequence_(sequence), pipeline_(pid) {}
 
     RenderSequencePtr sequence_;
-    PipelineID pipeline_id_;
+    PipelinePtr pipeline_;
 };
 
 class PipelineHelperAPIInterface {
@@ -67,7 +62,7 @@ public:
     virtual PipelinePtr pipeline(PipelineID pid) = 0;
     virtual bool enable_pipeline(PipelineID pid) = 0;
     virtual bool disable_pipeline(PipelineID pid) = 0;
-    virtual void delete_pipeline(PipelineID pid) = 0;
+    virtual PipelinePtr delete_pipeline(PipelineID pid) = 0;
     virtual bool has_pipeline(PipelineID pid) const = 0;
     virtual bool is_pipeline_enabled(PipelineID pid) const = 0;
 

--- a/simulant/render_sequence.cpp
+++ b/simulant/render_sequence.cpp
@@ -160,7 +160,7 @@ void RenderSequence::sort_pipelines(bool acquire_lock) {
     }
 }
 
-PipelineID RenderSequence::new_pipeline(StageID stage, CameraID camera, const Viewport& viewport, TextureID target, int32_t priority) {
+PipelinePtr RenderSequence::new_pipeline(StageID stage, CameraID camera, const Viewport& viewport, TextureID target, int32_t priority) {
     PipelineID new_p = PipelineManager::make(this);
 
     auto pipeline = PipelineManager::get(new_p).lock();
@@ -176,7 +176,7 @@ PipelineID RenderSequence::new_pipeline(StageID stage, CameraID camera, const Vi
     ordered_pipelines_.push_back(pipeline);
     sort_pipelines();
 
-    return new_p;
+    return pipeline.get();
 }
 
 void RenderSequence::set_renderer(Renderer* renderer) {

--- a/simulant/render_sequence.h
+++ b/simulant/render_sequence.h
@@ -103,7 +103,7 @@ public:
         delete_all_pipelines();
     }
 
-    PipelineID new_pipeline(
+    PipelinePtr new_pipeline(
         StageID stage,
         CameraID camera,
         const Viewport& viewport=Viewport(),

--- a/simulant/resource_manager.cpp
+++ b/simulant/resource_manager.cpp
@@ -173,10 +173,12 @@ MeshID ResourceManager::new_mesh_from_submesh(SubMesh* submesh, GarbageCollectMe
         if(old_to_new.count(old_index)) {
             target->index_data->index(old_to_new[old_index]);
         } else {
-            old_to_new[old_index] = submesh->vertex_data->copy_vertex_to_another(
+            auto j = submesh->vertex_data->copy_vertex_to_another(
                 *target->vertex_data.get(), submesh->index_data->at(i)
             );
-            target->index_data->index(i);
+
+            old_to_new[old_index] = j;
+            target->index_data->index(j);
         }
     }
 

--- a/simulant/resource_manager.cpp
+++ b/simulant/resource_manager.cpp
@@ -200,7 +200,12 @@ MeshID ResourceManager::new_mesh_from_file(const unicode& path, GarbageCollectMe
 
 MeshID ResourceManager::new_mesh_from_tmx_file(const unicode& tmx_file, const unicode& layer_name, float tile_render_size, GarbageCollectMethod garbage_collect) {
     smlt::MeshID mesh_id = new_mesh(VertexSpecification::DEFAULT, garbage_collect);
-    window->loader_for(tmx_file.encode())->into(mesh(mesh_id), {
+    auto mesh = mesh_id.fetch();
+
+    // There's no point maintaining adjacency info on a flat grid
+    mesh->set_maintain_adjacency_info(false);
+
+    window->loader_for(tmx_file.encode())->into(mesh, {
         {"layer", layer_name},
         {"render_size", tile_render_size}
     });
@@ -210,7 +215,12 @@ MeshID ResourceManager::new_mesh_from_tmx_file(const unicode& tmx_file, const un
 
 MeshID ResourceManager::new_mesh_from_heightmap(const unicode& image_file, const HeightmapSpecification& spec, GarbageCollectMethod garbage_collect) {
     smlt::MeshID mesh_id = new_mesh(VertexSpecification::DEFAULT, garbage_collect);
-    window->loader_for("heightmap_loader", image_file)->into(mesh(mesh_id), {
+    auto mesh = mesh_id.fetch();
+
+    // Heightmaps are huge, and calculating adjacency is slow, so.. don't do that by default (for now! maybe it can be optimised)
+    mesh->set_maintain_adjacency_info(false);
+
+    window->loader_for("heightmap_loader", image_file)->into(mesh, {
         { "spec", spec},
     });
     MeshManager::mark_as_uncollected(mesh_id);

--- a/simulant/scenes/loading.cpp
+++ b/simulant/scenes/loading.cpp
@@ -34,32 +34,31 @@ void Loading::load() {
     //Create a stage
     stage_ = window->new_stage();
 
-    auto stage = stage_.fetch();
-    progress_bar_ = dynamic_cast<ui::ProgressBar*>((ui::Widget*) stage->ui->new_widget_as_progress_bar().fetch());
+    progress_bar_ = dynamic_cast<ui::ProgressBar*>((ui::Widget*) stage_->ui->new_widget_as_progress_bar().fetch());
     progress_bar_->resize(window->width() * 0.5f, 8);
     progress_bar_->move_to(window->coordinate_from_normalized(0.5, 0.5));
     progress_bar_->set_pulse_step(progress_bar_->requested_width());
 
-    auto label = stage->ui->new_widget_as_label("LOADING").fetch();
+    auto label = stage_->ui->new_widget_as_label("LOADING").fetch();
     label->move_to(window->coordinate_from_normalized(0.5, 0.55));
     label->set_background_colour(smlt::Colour::NONE);
 
     //Create an orthographic camera
-    camera_ = stage_.fetch()->new_camera();
+    camera_ = stage_->new_camera();
 
     camera_.fetch()->set_orthographic_projection(
         0, window->width(), 0, window->height()
     );
 
     //Create an inactive pipeline
-    pipeline_ = window->render(stage_, camera_);
+    pipeline_ = window->render(stage_->id(), camera_);
     window->disable_pipeline(pipeline_);
 }
 
 void Loading::unload() {
     //Clean up
     window->delete_pipeline(pipeline_);
-    window->delete_stage(stage_);    
+    window->delete_stage(stage_->id());
 }
 
 void Loading::activate() {

--- a/simulant/scenes/loading.cpp
+++ b/simulant/scenes/loading.cpp
@@ -23,6 +23,7 @@
 #include "../nodes/camera.h"
 #include "../window.h"
 #include "../nodes/ui/ui_manager.h"
+#include "../nodes/ui/label.h"
 
 #include "loading.h"
 
@@ -34,12 +35,12 @@ void Loading::load() {
     //Create a stage
     stage_ = window->new_stage();
 
-    progress_bar_ = dynamic_cast<ui::ProgressBar*>((ui::Widget*) stage_->ui->new_widget_as_progress_bar().fetch());
+    progress_bar_ = stage_->ui->new_widget_as_progress_bar();
     progress_bar_->resize(window->width() * 0.5f, 8);
     progress_bar_->move_to(window->coordinate_from_normalized(0.5, 0.5));
     progress_bar_->set_pulse_step(progress_bar_->requested_width());
 
-    auto label = stage_->ui->new_widget_as_label("LOADING").fetch();
+    auto label = stage_->ui->new_widget_as_label("LOADING");
     label->move_to(window->coordinate_from_normalized(0.5, 0.55));
     label->set_background_colour(smlt::Colour::NONE);
 

--- a/simulant/scenes/loading.cpp
+++ b/simulant/scenes/loading.cpp
@@ -35,7 +35,7 @@ void Loading::load() {
     stage_ = window->new_stage();
 
     auto stage = stage_.fetch();
-    progress_bar_ = dynamic_cast<ui::ProgressBar*>(stage->ui->new_widget_as_progress_bar().fetch());
+    progress_bar_ = dynamic_cast<ui::ProgressBar*>((ui::Widget*) stage->ui->new_widget_as_progress_bar().fetch());
     progress_bar_->resize(window->width() * 0.5f, 8);
     progress_bar_->move_to(window->coordinate_from_normalized(0.5, 0.5));
     progress_bar_->set_pulse_step(progress_bar_->requested_width());

--- a/simulant/scenes/loading.cpp
+++ b/simulant/scenes/loading.cpp
@@ -52,22 +52,22 @@ void Loading::load() {
 
     //Create an inactive pipeline
     pipeline_ = window->render(stage_, camera_);
-    window->disable_pipeline(pipeline_);
+    pipeline_->deactivate();
 }
 
 void Loading::unload() {
     //Clean up
-    window->delete_pipeline(pipeline_);
+    pipeline_->deactivate();
     window->delete_stage(stage_->id());
 }
 
 void Loading::activate() {
-    window->enable_pipeline(pipeline_);
+    pipeline_->activate();
 }
 
 void Loading::deactivate() {
     //Deactivate the loading pipeline
-    window->disable_pipeline(pipeline_);
+    pipeline_->deactivate();
 }
 
 }

--- a/simulant/scenes/loading.cpp
+++ b/simulant/scenes/loading.cpp
@@ -46,12 +46,12 @@ void Loading::load() {
     //Create an orthographic camera
     camera_ = stage_->new_camera();
 
-    camera_.fetch()->set_orthographic_projection(
+    camera_->set_orthographic_projection(
         0, window->width(), 0, window->height()
     );
 
     //Create an inactive pipeline
-    pipeline_ = window->render(stage_->id(), camera_);
+    pipeline_ = window->render(stage_, camera_);
     window->disable_pipeline(pipeline_);
 }
 

--- a/simulant/scenes/loading.h
+++ b/simulant/scenes/loading.h
@@ -49,7 +49,7 @@ private:
     void unload() override;
 
     StagePtr stage_;
-    CameraID camera_;
+    CameraPtr camera_;
     PipelineID pipeline_;
 
     ui::ProgressBar* progress_bar_ = nullptr;

--- a/simulant/scenes/loading.h
+++ b/simulant/scenes/loading.h
@@ -50,7 +50,7 @@ private:
 
     StagePtr stage_;
     CameraPtr camera_;
-    PipelineID pipeline_;
+    PipelinePtr pipeline_;
 
     ui::ProgressBar* progress_bar_ = nullptr;
 };

--- a/simulant/scenes/loading.h
+++ b/simulant/scenes/loading.h
@@ -48,7 +48,7 @@ private:
     void load() override;
     void unload() override;
 
-    StageID stage_;
+    StagePtr stage_;
     CameraID camera_;
     PipelineID pipeline_;
 

--- a/simulant/scenes/scene.cpp
+++ b/simulant/scenes/scene.cpp
@@ -66,10 +66,10 @@ void SceneBase::_call_deactivate() {
     is_active_ = false;
 }
 
-PipelineID SceneBase::prepare_basic_scene(StagePtr& new_stage, CameraID& new_camera, AvailablePartitioner partitioner) {
+PipelineID SceneBase::prepare_basic_scene(StagePtr& new_stage, CameraPtr& new_camera, AvailablePartitioner partitioner) {
     new_stage = window->new_stage(partitioner);
     new_camera = new_stage->new_camera();
-    return window->render(new_stage->id(), new_camera);
+    return window->render(new_stage, new_camera);
 }
 
 }

--- a/simulant/scenes/scene.cpp
+++ b/simulant/scenes/scene.cpp
@@ -66,10 +66,10 @@ void SceneBase::_call_deactivate() {
     is_active_ = false;
 }
 
-PipelineID SceneBase::prepare_basic_scene(StageID& new_stage, CameraID& new_camera, AvailablePartitioner partitioner) {
+PipelineID SceneBase::prepare_basic_scene(StagePtr& new_stage, CameraID& new_camera, AvailablePartitioner partitioner) {
     new_stage = window->new_stage(partitioner);
-    new_camera = new_stage.fetch()->new_camera();
-    return window->render(new_stage, new_camera);
+    new_camera = new_stage->new_camera();
+    return window->render(new_stage->id(), new_camera);
 }
 
 }

--- a/simulant/scenes/scene.cpp
+++ b/simulant/scenes/scene.cpp
@@ -66,7 +66,7 @@ void SceneBase::_call_deactivate() {
     is_active_ = false;
 }
 
-PipelineID SceneBase::prepare_basic_scene(StagePtr& new_stage, CameraPtr& new_camera, AvailablePartitioner partitioner) {
+PipelinePtr SceneBase::prepare_basic_scene(StagePtr& new_stage, CameraPtr& new_camera, AvailablePartitioner partitioner) {
     new_stage = window->new_stage(partitioner);
     new_camera = new_stage->new_camera();
     return window->render(new_stage, new_camera);

--- a/simulant/scenes/scene.h
+++ b/simulant/scenes/scene.h
@@ -98,8 +98,7 @@ protected:
     virtual void activate() {}
     virtual void deactivate() {}
 
-    PipelineID prepare_basic_scene(
-        StageID& new_stage,
+    PipelineID prepare_basic_scene(StagePtr &new_stage,
         CameraID& new_camera,
         AvailablePartitioner partitioner=PARTITIONER_HASH
     );

--- a/simulant/scenes/scene.h
+++ b/simulant/scenes/scene.h
@@ -98,7 +98,7 @@ protected:
     virtual void activate() {}
     virtual void deactivate() {}
 
-    PipelineID prepare_basic_scene(StagePtr &new_stage,
+    PipelinePtr prepare_basic_scene(StagePtr &new_stage,
         CameraPtr &new_camera,
         AvailablePartitioner partitioner=PARTITIONER_HASH
     );

--- a/simulant/scenes/scene.h
+++ b/simulant/scenes/scene.h
@@ -99,7 +99,7 @@ protected:
     virtual void deactivate() {}
 
     PipelineID prepare_basic_scene(StagePtr &new_stage,
-        CameraID& new_camera,
+        CameraPtr &new_camera,
         AvailablePartitioner partitioner=PARTITIONER_HASH
     );
 

--- a/simulant/stage.cpp
+++ b/simulant/stage.cpp
@@ -268,7 +268,7 @@ void Stage::delete_particle_system(ParticleSystemID pid) {
     ParticleSystemManager::destroy(pid);
 }
 
-LightID Stage::new_light_as_directional(const Vec3& direction, const smlt::Colour& colour) {
+LightPtr Stage::new_light_as_directional(const Vec3& direction, const smlt::Colour& colour) {
     auto light = LightManager::make(this).fetch();
     auto light_id = light->id();
 
@@ -282,11 +282,11 @@ LightID Stage::new_light_as_directional(const Vec3& direction, const smlt::Colou
         this->partitioner->update_light(light_id, new_bounds);
     });
 
-    signal_light_created_(light->id());
-    return light->id();
+    signal_light_created_(light_id);
+    return light;
 }
 
-LightID Stage::new_light_as_point(const Vec3& position, const smlt::Colour& colour) {
+LightPtr Stage::new_light_as_point(const Vec3& position, const smlt::Colour& colour) {
     auto light = LightManager::make(this).fetch();
     auto light_id = light->id();
 
@@ -301,8 +301,8 @@ LightID Stage::new_light_as_point(const Vec3& position, const smlt::Colour& colo
         this->partitioner->update_light(light_id, new_bounds);
     });
 
-    signal_light_created_(light->id());
-    return light->id();
+    signal_light_created_(light_id);
+    return light;
 }
 
 LightPtr Stage::light(LightID light_id) {

--- a/simulant/stage.cpp
+++ b/simulant/stage.cpp
@@ -220,7 +220,7 @@ std::size_t Stage::geom_count() const {
 
 //=============== PARTICLES =================
 
-ParticleSystemID Stage::new_particle_system() {
+ParticleSystemPtr Stage::new_particle_system() {
     ParticleSystemID new_id = ParticleSystemManager::make(this, window->_sound_driver());
 
     auto p = new_id.fetch();
@@ -231,31 +231,28 @@ ParticleSystemID Stage::new_particle_system() {
     });
 
     signal_particle_system_created_(new_id);
-    return new_id;
+    return p;
 }
 
-ParticleSystemID Stage::new_particle_system_from_file(const unicode& filename, bool destroy_on_completion) {
-    ParticleSystemID new_id = new_particle_system();
+ParticleSystemPtr Stage::new_particle_system_from_file(const unicode& filename, bool destroy_on_completion) {
+    auto ps = new_particle_system();
 
-    auto ps = particle_system(new_id)->shared_from_this();
     ps->set_parent(this);
     ps->set_destroy_on_completion(destroy_on_completion);
 
     window->loader_for(filename)->into(ps);
 
-    return new_id;
+    return ps;
 }
 
-ParticleSystemID Stage::new_particle_system_with_parent_from_file(ActorID parent, const unicode& filename, bool destroy_on_completion) {
-    ParticleSystemID new_id = new_particle_system();
-
-    auto ps = particle_system(new_id)->shared_from_this();
+ParticleSystemPtr Stage::new_particle_system_with_parent_from_file(ActorID parent, const unicode& filename, bool destroy_on_completion) {
+    auto ps = new_particle_system();
     ps->set_parent(parent);
     ps->set_destroy_on_completion(destroy_on_completion);
 
     window->loader_for(filename)->into(ps);
 
-    return new_id;
+    return ps;
 }
 
 ParticleSystemPtr Stage::particle_system(ParticleSystemID pid) {

--- a/simulant/stage.cpp
+++ b/simulant/stage.cpp
@@ -182,11 +182,11 @@ void Stage::delete_actor(ActorID e) {
 
 //=============== GEOMS =====================
 
-GeomID Stage::new_geom_with_mesh(MeshID mid) {
-    auto gid = geom_manager_->make(this, window->_sound_driver(), mid);
-    geom(gid)->set_parent(this);
+GeomPtr Stage::new_geom_with_mesh(MeshID mid) {
+    auto gid = geom_manager_->make(this, window->_sound_driver(), mid).fetch();
+    gid->set_parent(this);
 
-    signal_geom_created_(gid);
+    signal_geom_created_(gid->id());
 
     return gid;
 }
@@ -195,11 +195,11 @@ GeomPtr Stage::geom(const GeomID gid) const {
     return geom_manager_->get(gid);
 }
 
-GeomID Stage::new_geom_with_mesh_at_position(MeshID mid, const Vec3& position, const Quaternion& rotation) {
-    auto gid = geom_manager_->make(this, window->_sound_driver(), mid, position, rotation);
-    geom(gid)->set_parent(this);
+GeomPtr Stage::new_geom_with_mesh_at_position(MeshID mid, const Vec3& position, const Quaternion& rotation) {
+    auto gid = geom_manager_->make(this, window->_sound_driver(), mid, position, rotation).fetch();
+    gid->set_parent(this);
 
-    signal_geom_created_(gid);
+    signal_geom_created_(gid->id());
 
     return gid;
 }
@@ -214,7 +214,7 @@ void Stage::delete_geom(GeomID geom_id) {
     geom_manager_->destroy(geom_id);
 }
 
-uint32_t Stage::geom_count() const {
+std::size_t Stage::geom_count() const {
     return geom_manager_->count();
 }
 

--- a/simulant/stage.cpp
+++ b/simulant/stage.cpp
@@ -175,9 +175,10 @@ const ActorPtr Stage::actor(ActorID e) const {
     return ActorManager::get(e);
 }
 
-void Stage::delete_actor(ActorID e) {
+ActorPtr Stage::delete_actor(ActorID e) {
     signal_actor_destroyed_(e);
     ActorManager::destroy(e);
+    return nullptr;
 }
 
 //=============== GEOMS =====================
@@ -208,10 +209,11 @@ bool Stage::has_geom(GeomID geom_id) const {
     return geom_manager_->contains(geom_id);
 }
 
-void Stage::delete_geom(GeomID geom_id) {
+GeomPtr Stage::delete_geom(GeomID geom_id) {
     signal_geom_destroyed_(geom_id);
 
     geom_manager_->destroy(geom_id);
+    return nullptr;
 }
 
 std::size_t Stage::geom_count() const {
@@ -263,9 +265,10 @@ bool Stage::has_particle_system(ParticleSystemID pid) const {
     return ParticleSystemManager::contains(pid);
 }
 
-void Stage::delete_particle_system(ParticleSystemID pid) {
+ParticleSystemPtr Stage::delete_particle_system(ParticleSystemID pid) {
     signal_particle_system_destroyed_(pid);
     ParticleSystemManager::destroy(pid);
+    return nullptr;
 }
 
 LightPtr Stage::new_light_as_directional(const Vec3& direction, const smlt::Colour& colour) {
@@ -309,9 +312,10 @@ LightPtr Stage::light(LightID light_id) {
     return LightManager::get(light_id);
 }
 
-void Stage::delete_light(LightID light_id) {
+LightPtr Stage::delete_light(LightID light_id) {
     signal_light_destroyed_(light_id);
     LightManager::destroy(light_id);
+    return nullptr;
 }
 
 void Stage::set_partitioner(AvailablePartitioner partitioner) {

--- a/simulant/stage.cpp
+++ b/simulant/stage.cpp
@@ -95,7 +95,7 @@ void Stage::on_subactor_material_changed(
     signal_actor_changed_(actor_id, evt);
 }
 
-ActorID Stage::new_actor(RenderableCullingMode mode) {
+ActorPtr Stage::new_actor(RenderableCullingMode mode) {
     using namespace std::placeholders;
 
     ActorID result = ActorManager::make(this, window->_sound_driver());
@@ -114,10 +114,10 @@ ActorID Stage::new_actor(RenderableCullingMode mode) {
 
     //Tell everyone about the new actor
     signal_actor_created_(result);
-    return result;
+    return a;
 }
 
-ActorID Stage::new_actor_with_mesh(MeshID mid, RenderableCullingMode mode) {
+ActorPtr Stage::new_actor_with_mesh(MeshID mid, RenderableCullingMode mode) {
     using namespace std::placeholders;
 
     ActorID result = ActorManager::make(this, window->_sound_driver());
@@ -142,25 +142,25 @@ ActorID Stage::new_actor_with_mesh(MeshID mid, RenderableCullingMode mode) {
     //Tell everyone about the new actor
     signal_actor_created_(result);
 
-    return result;
+    return a;
 }
 
-ActorID Stage::new_actor_with_parent(ActorID parent, RenderableCullingMode mode) {
-    ActorID new_id = new_actor(mode);
-    actor(new_id)->set_parent(parent);
-    return new_id;
+ActorPtr Stage::new_actor_with_parent(ActorID parent, RenderableCullingMode mode) {
+    auto a = new_actor(mode);
+    a->set_parent(parent);
+    return a;
 }
 
-ActorID Stage::new_actor_with_parent_and_mesh(SpriteID parent, MeshID mid, RenderableCullingMode mode) {
-    ActorID new_id = new_actor_with_mesh(mid, mode);
-    actor(new_id)->set_parent(parent);
-    return new_id;
+ActorPtr Stage::new_actor_with_parent_and_mesh(SpriteID parent, MeshID mid, RenderableCullingMode mode) {
+    auto a = new_actor_with_mesh(mid, mode);
+    a->set_parent(parent);
+    return a;
 }
 
-ActorID Stage::new_actor_with_parent_and_mesh(ActorID parent, MeshID mid, RenderableCullingMode mode) {
-    ActorID new_id = new_actor_with_mesh(mid, mode);
-    actor(new_id)->set_parent(parent);
-    return new_id;
+ActorPtr Stage::new_actor_with_parent_and_mesh(ActorID parent, MeshID mid, RenderableCullingMode mode) {
+    auto a = new_actor_with_mesh(mid, mode);
+    a->set_parent(parent);
+    return a;
 }
 
 bool Stage::has_actor(ActorID m) const {

--- a/simulant/stage.h
+++ b/simulant/stage.h
@@ -111,12 +111,16 @@ public:
     Stage(StageID id, Window *parent, AvailablePartitioner partitioner);
     ~Stage();
 
-    ActorID new_actor(RenderableCullingMode mode=RENDERABLE_CULLING_MODE_PARTITIONER);
-    ActorID new_actor_with_mesh(MeshID mid, RenderableCullingMode mode=RENDERABLE_CULLING_MODE_PARTITIONER);
-
-    ActorID new_actor_with_parent(ActorID parent, RenderableCullingMode mode=RENDERABLE_CULLING_MODE_PARTITIONER);
-    ActorID new_actor_with_parent_and_mesh(ActorID parent, MeshID mid, RenderableCullingMode mode=RENDERABLE_CULLING_MODE_PARTITIONER);
-    ActorID new_actor_with_parent_and_mesh(SpriteID parent, MeshID mid, RenderableCullingMode mode=RENDERABLE_CULLING_MODE_PARTITIONER);
+    ActorPtr new_actor(RenderableCullingMode mode=RENDERABLE_CULLING_MODE_PARTITIONER);
+    ActorPtr new_actor_with_mesh(MeshID mid, RenderableCullingMode mode=RENDERABLE_CULLING_MODE_PARTITIONER);
+    ActorPtr new_actor_with_parent(ActorID parent, RenderableCullingMode mode=RENDERABLE_CULLING_MODE_PARTITIONER);
+    ActorPtr new_actor_with_parent_and_mesh(ActorID parent, MeshID mid, RenderableCullingMode mode=RENDERABLE_CULLING_MODE_PARTITIONER);
+    ActorPtr new_actor_with_parent_and_mesh(SpriteID parent, MeshID mid, RenderableCullingMode mode=RENDERABLE_CULLING_MODE_PARTITIONER);
+    ActorPtr actor(ActorID e);
+    const ActorPtr actor(ActorID e) const;
+    bool has_actor(ActorID e) const;
+    void delete_actor(ActorID e);
+    std::size_t actor_count() const { return ActorManager::count(); }
 
     GeomID new_geom_with_mesh(MeshID mid);
     GeomID new_geom_with_mesh_at_position(MeshID mid, const Vec3& position, const Quaternion& rotation=Quaternion());
@@ -124,13 +128,6 @@ public:
     bool has_geom(GeomID geom_id) const;
     void delete_geom(GeomID geom_id);
     uint32_t geom_count() const;
-
-    ActorPtr actor(ActorID e);
-    const ActorPtr actor(ActorID e) const;
-
-    bool has_actor(ActorID e) const;
-    void delete_actor(ActorID e);
-    uint32_t actor_count() const { return ActorManager::count(); }
 
     ParticleSystemID new_particle_system();
     ParticleSystemID new_particle_system_from_file(const unicode& filename, bool destroy_on_completion=false);

--- a/simulant/stage.h
+++ b/simulant/stage.h
@@ -137,8 +137,8 @@ public:
     void delete_particle_system(ParticleSystemID pid);
     std::size_t particle_system_count() const { return ParticleSystemManager::count(); }
 
-    LightID new_light_as_directional(const Vec3& direction=Vec3(1, -0.5, 0), const smlt::Colour& colour=DEFAULT_LIGHT_COLOUR);
-    LightID new_light_as_point(const Vec3& position=Vec3(), const smlt::Colour& colour=DEFAULT_LIGHT_COLOUR);
+    LightPtr new_light_as_directional(const Vec3& direction=Vec3(1, -0.5, 0), const smlt::Colour& colour=DEFAULT_LIGHT_COLOUR);
+    LightPtr new_light_as_point(const Vec3& position=Vec3(), const smlt::Colour& colour=DEFAULT_LIGHT_COLOUR);
 
     LightPtr light(LightID light);
     void delete_light(LightID light_id);

--- a/simulant/stage.h
+++ b/simulant/stage.h
@@ -122,12 +122,12 @@ public:
     void delete_actor(ActorID e);
     std::size_t actor_count() const { return ActorManager::count(); }
 
-    GeomID new_geom_with_mesh(MeshID mid);
-    GeomID new_geom_with_mesh_at_position(MeshID mid, const Vec3& position, const Quaternion& rotation=Quaternion());
+    GeomPtr new_geom_with_mesh(MeshID mid);
+    GeomPtr new_geom_with_mesh_at_position(MeshID mid, const Vec3& position, const Quaternion& rotation=Quaternion());
     GeomPtr geom(const GeomID gid) const;
     bool has_geom(GeomID geom_id) const;
     void delete_geom(GeomID geom_id);
-    uint32_t geom_count() const;
+    std::size_t geom_count() const;
 
     ParticleSystemID new_particle_system();
     ParticleSystemID new_particle_system_from_file(const unicode& filename, bool destroy_on_completion=false);

--- a/simulant/stage.h
+++ b/simulant/stage.h
@@ -119,14 +119,14 @@ public:
     ActorPtr actor(ActorID e);
     const ActorPtr actor(ActorID e) const;
     bool has_actor(ActorID e) const;
-    void delete_actor(ActorID e);
+    ActorPtr delete_actor(ActorID e);
     std::size_t actor_count() const { return ActorManager::count(); }
 
     GeomPtr new_geom_with_mesh(MeshID mid);
     GeomPtr new_geom_with_mesh_at_position(MeshID mid, const Vec3& position, const Quaternion& rotation=Quaternion());
     GeomPtr geom(const GeomID gid) const;
     bool has_geom(GeomID geom_id) const;
-    void delete_geom(GeomID geom_id);
+    GeomPtr delete_geom(GeomID geom_id);
     std::size_t geom_count() const;
 
     ParticleSystemPtr new_particle_system();
@@ -134,14 +134,14 @@ public:
     ParticleSystemPtr new_particle_system_with_parent_from_file(ActorID parent, const unicode& filename, bool destroy_on_completion=false);
     ParticleSystemPtr particle_system(ParticleSystemID pid);
     bool has_particle_system(ParticleSystemID pid) const;
-    void delete_particle_system(ParticleSystemID pid);
+    ParticleSystemPtr delete_particle_system(ParticleSystemID pid);
     std::size_t particle_system_count() const { return ParticleSystemManager::count(); }
 
     LightPtr new_light_as_directional(const Vec3& direction=Vec3(1, -0.5, 0), const smlt::Colour& colour=DEFAULT_LIGHT_COLOUR);
     LightPtr new_light_as_point(const Vec3& position=Vec3(), const smlt::Colour& colour=DEFAULT_LIGHT_COLOUR);
 
     LightPtr light(LightID light);
-    void delete_light(LightID light_id);
+    LightPtr delete_light(LightID light_id);
     std::size_t light_count() const { return LightManager::count(); }
 
 
@@ -229,7 +229,6 @@ private:
     void on_actor_destroyed(ActorID actor_id);
     void on_subactor_material_changed(ActorID actor_id, SubActor* subactor, MaterialID old, MaterialID newM);
 };
-
 
 }
 #endif // SUBSCENE_H

--- a/simulant/stage.h
+++ b/simulant/stage.h
@@ -129,13 +129,13 @@ public:
     void delete_geom(GeomID geom_id);
     std::size_t geom_count() const;
 
-    ParticleSystemID new_particle_system();
-    ParticleSystemID new_particle_system_from_file(const unicode& filename, bool destroy_on_completion=false);
-    ParticleSystemID new_particle_system_with_parent_from_file(ActorID parent, const unicode& filename, bool destroy_on_completion=false);
+    ParticleSystemPtr new_particle_system();
+    ParticleSystemPtr new_particle_system_from_file(const unicode& filename, bool destroy_on_completion=false);
+    ParticleSystemPtr new_particle_system_with_parent_from_file(ActorID parent, const unicode& filename, bool destroy_on_completion=false);
     ParticleSystemPtr particle_system(ParticleSystemID pid);
     bool has_particle_system(ParticleSystemID pid) const;
     void delete_particle_system(ParticleSystemID pid);
-    uint32_t particle_system_count() const { return ParticleSystemManager::count(); }
+    std::size_t particle_system_count() const { return ParticleSystemManager::count(); }
 
     LightID new_light_as_directional(const Vec3& direction=Vec3(1, -0.5, 0), const smlt::Colour& colour=DEFAULT_LIGHT_COLOUR);
     LightID new_light_as_point(const Vec3& position=Vec3(), const smlt::Colour& colour=DEFAULT_LIGHT_COLOUR);

--- a/simulant/stage.h
+++ b/simulant/stage.h
@@ -142,7 +142,7 @@ public:
 
     LightPtr light(LightID light);
     void delete_light(LightID light_id);
-    uint32_t light_count() const { return LightManager::count(); }
+    std::size_t light_count() const { return LightManager::count(); }
 
 
     smlt::Colour ambient_light() const { return ambient_light_; }

--- a/simulant/types.h
+++ b/simulant/types.h
@@ -449,16 +449,6 @@ public:
     default_init_ptr(T* p):
         ptr_(p) {}
 
-    default_init_ptr(std::nullptr_t p):
-        ptr_(p) {
-
-    }
-
-    default_init_ptr<T>& operator=(std::nullptr_t) {
-        ptr_ = nullptr;
-        return *this;
-    }
-
     default_init_ptr<T>& operator=(T* p) {
         ptr_ = p;
         return *this;
@@ -478,14 +468,6 @@ public:
 
     operator T*() const {
         return ptr_;
-    }
-
-    bool operator==(const std::nullptr_t& rhs) const {
-        return ptr_ == rhs;
-    }
-
-    bool operator!=(const std::nullptr_t& rhs) const {
-        return !(*this == rhs);
     }
 };
 

--- a/simulant/types.h
+++ b/simulant/types.h
@@ -427,35 +427,97 @@ class Font;
 typedef std::weak_ptr<Font> FontRef;
 typedef std::shared_ptr<Font> FontPtr;
 
+
+template<typename T>
+class default_init_ptr {
+    /* This class exists to protect against forgetting to initialize a
+     * an object pointer. It could theoretically cause a performance issue
+     * but no more so than any other smart pointer, and hopefully the compiler
+     * will be smart enough to optimise any cost away.
+     *
+     * If this does cause a performance hit on a particular platform
+     * (Dreamcast, I'm looking at you!) then it can always be typedef'd away
+     */
+private:
+    T* ptr_ = nullptr;
+
+public:
+    default_init_ptr() = default;
+    default_init_ptr(const default_init_ptr<T>&) = default;
+    default_init_ptr<T>& operator=(const default_init_ptr<T>&) = default;
+
+    default_init_ptr(T* p):
+        ptr_(p) {}
+
+    default_init_ptr(std::nullptr_t p):
+        ptr_(p) {
+
+    }
+
+    default_init_ptr<T>& operator=(std::nullptr_t) {
+        ptr_ = nullptr;
+        return *this;
+    }
+
+    default_init_ptr<T>& operator=(T* p) {
+        ptr_ = p;
+        return *this;
+    }
+
+    T* operator->() const {
+        return ptr_;
+    }
+
+    T& operator*() const {
+        return *ptr_;
+    }
+
+    T& operator[](std::size_t i) const {
+        return ptr_[i];
+    }
+
+    operator T*() const {
+        return ptr_;
+    }
+
+    bool operator==(const std::nullptr_t& rhs) const {
+        return ptr_ == rhs;
+    }
+
+    bool operator!=(const std::nullptr_t& rhs) const {
+        return !(*this == rhs);
+    }
+};
+
+
 class Actor;
-typedef Actor* ActorPtr;
+typedef default_init_ptr<Actor> ActorPtr;
 
 class Geom;
-typedef Geom* GeomPtr;
+typedef default_init_ptr<Geom> GeomPtr;
 
 class ParticleSystem;
-typedef ParticleSystem* ParticleSystemPtr;
+typedef default_init_ptr<ParticleSystem> ParticleSystemPtr;
 
 class Sprite;
-typedef Sprite* SpritePtr;
+typedef default_init_ptr<Sprite> SpritePtr;
 
 class Light;
-typedef Light* LightPtr;
+typedef default_init_ptr<Light> LightPtr;
 
 class Camera;
 class CameraProxy;
 
-typedef Camera* CameraPtr;
-typedef CameraProxy* CameraProxyPtr;
+typedef default_init_ptr<Camera> CameraPtr;
 
 class Viewport;
 
 class Background;
-typedef Background* BackgroundPtr;
+typedef default_init_ptr<Background> BackgroundPtr;
 
 class Stage;
 class Window;
-typedef Stage* StagePtr;
+typedef default_init_ptr<Stage> StagePtr;
 
 namespace ui {
 
@@ -464,7 +526,7 @@ class ProgressBar;
 class Button;
 class Label;
 
-typedef Widget* WidgetPtr;
+typedef default_init_ptr<Widget> WidgetPtr;
 
 }
 
@@ -475,7 +537,7 @@ class RenderSequence;
 typedef AutoWeakPtr<RenderSequence> RenderSequencePtr;
 
 class Pipeline;
-typedef Pipeline* PipelinePtr;
+typedef default_init_ptr<Pipeline> PipelinePtr;
 
 class Frustum;
 class Window;

--- a/simulant/virtual_gamepad.cpp
+++ b/simulant/virtual_gamepad.cpp
@@ -43,17 +43,16 @@ bool VirtualGamepad::init() {
     stage_ = window_.new_stage(); //Create a Stage to hold the controller buttons
 
     uint32_t button_size = int(float(window_.width() / 10.0));
-    auto stage = stage_.fetch();
 
     if(this->config_ == VIRTUAL_GAMEPAD_CONFIG_TWO_BUTTONS) {
-        auto button1 = stage->ui->new_widget_as_button("L").fetch_as<ui::Button>();
-        auto button2 = stage->ui->new_widget_as_button("R").fetch_as<ui::Button>();
+        auto button1 = stage_->ui->new_widget_as_button("L").fetch_as<ui::Button>();
+        auto button2 = stage_->ui->new_widget_as_button("R").fetch_as<ui::Button>();
 
         button1->set_background_colour(smlt::Colour(0, 0, 0, 0.2));
         button2->set_background_colour(smlt::Colour(0, 0, 0, 0.2));
 
-        button1->set_font(stage->assets->default_font_id(DEFAULT_FONT_STYLE_HEADING));
-        button2->set_font(stage->assets->default_font_id(DEFAULT_FONT_STYLE_HEADING));
+        button1->set_font(stage_->assets->default_font_id(DEFAULT_FONT_STYLE_HEADING));
+        button2->set_font(stage_->assets->default_font_id(DEFAULT_FONT_STYLE_HEADING));
 
         button1->move_to(window_.coordinate_from_normalized(0.10, 0.10 * window_.aspect_ratio()));
         button2->move_to(window_.coordinate_from_normalized(0.90, 0.10 * window_.aspect_ratio()));
@@ -83,10 +82,10 @@ bool VirtualGamepad::init() {
         assert(0 && "Not Implemented");
     }
 
-    camera_id_ = stage->new_camera_with_orthographic_projection();
+    camera_id_ = stage_->new_camera_with_orthographic_projection();
 
     //Finally add to the render sequence, give a ridiculously high priority
-    pipeline_id_ = window_.render(stage_, camera_id_).with_priority(smlt::RENDER_PRIORITY_ABSOLUTE_FOREGROUND);
+    pipeline_id_ = window_.render(stage_->id(), camera_id_).with_priority(smlt::RENDER_PRIORITY_ABSOLUTE_FOREGROUND);
 
     return true;
 }
@@ -96,7 +95,7 @@ void VirtualGamepad::_prepare_deletion() {
 
     // make sure we delete the buttons before we delete the gamepad
     for(auto& button: buttons_) {
-        stage_.fetch()->ui->delete_widget(button->id());
+        stage_->ui->delete_widget(button->id());
     }
 }
 
@@ -104,7 +103,7 @@ void VirtualGamepad::cleanup() {
     L_DEBUG("Destroying virtual gamepad");
 
     window_.delete_pipeline(pipeline_id_);
-    window_.delete_stage(stage_);
+    window_.delete_stage(stage_->id());
 }
 
 void VirtualGamepad::flip() {

--- a/simulant/virtual_gamepad.cpp
+++ b/simulant/virtual_gamepad.cpp
@@ -46,8 +46,8 @@ bool VirtualGamepad::init() {
     uint32_t button_size = int(float(window_.width() / 10.0));
 
     if(this->config_ == VIRTUAL_GAMEPAD_CONFIG_TWO_BUTTONS) {
-        auto button1 = stage_->ui->new_widget_as_button("L").fetch_as<ui::Button>();
-        auto button2 = stage_->ui->new_widget_as_button("R").fetch_as<ui::Button>();
+        auto button1 = stage_->ui->new_widget_as_button("L");
+        auto button2 = stage_->ui->new_widget_as_button("R");
 
         button1->set_background_colour(smlt::Colour(0, 0, 0, 0.2));
         button2->set_background_colour(smlt::Colour(0, 0, 0, 0.2));

--- a/simulant/virtual_gamepad.cpp
+++ b/simulant/virtual_gamepad.cpp
@@ -82,10 +82,10 @@ bool VirtualGamepad::init() {
         assert(0 && "Not Implemented");
     }
 
-    camera_id_ = stage_->new_camera_with_orthographic_projection();
+    camera_ = stage_->new_camera_with_orthographic_projection();
 
     //Finally add to the render sequence, give a ridiculously high priority
-    pipeline_id_ = window_.render(stage_->id(), camera_id_).with_priority(smlt::RENDER_PRIORITY_ABSOLUTE_FOREGROUND);
+    pipeline_id_ = window_.render(stage_, camera_).with_priority(smlt::RENDER_PRIORITY_ABSOLUTE_FOREGROUND);
 
     return true;
 }

--- a/simulant/virtual_gamepad.h
+++ b/simulant/virtual_gamepad.h
@@ -56,7 +56,7 @@ private:
     std::vector<ui::Button*> buttons_;
 
     StagePtr stage_;
-    CameraID camera_id_;
+    CameraPtr camera_;
     PipelineID pipeline_id_;
 
     sig::signal<void (int)> signal_button_down_;

--- a/simulant/virtual_gamepad.h
+++ b/simulant/virtual_gamepad.h
@@ -56,7 +56,10 @@ private:
     std::vector<ui::Button*> buttons_;
 
     StagePtr stage_;
+    StageID stage_id_;
+
     CameraPtr camera_;
+    PipelinePtr pipeline_;
     PipelineID pipeline_id_;
 
     sig::signal<void (int)> signal_button_down_;

--- a/simulant/virtual_gamepad.h
+++ b/simulant/virtual_gamepad.h
@@ -22,6 +22,7 @@
 #include <unordered_map>
 #include "deps/kazsignal/kazsignal.h"
 #include "generic/managed.h"
+#include "generic/property.h"
 #include "types.h"
 
 #include "input/input_state.h"
@@ -46,7 +47,7 @@ public:
     AABB button_bounds(int button);
 
 
-    StageID stage_id() const { return stage_; }
+    Property<VirtualGamepad, Stage> stage = {this, &VirtualGamepad::stage_};
 
 private:
     Window& window_;
@@ -54,7 +55,7 @@ private:
 
     std::vector<ui::Button*> buttons_;
 
-    StageID stage_;
+    StagePtr stage_;
     CameraID camera_id_;
     PipelineID pipeline_id_;
 

--- a/simulant/window.cpp
+++ b/simulant/window.cpp
@@ -494,8 +494,9 @@ bool Window::disable_pipeline(PipelineID pid) {
     return state != pipeline->is_active();
 }
 
-void Window::delete_pipeline(PipelineID pid) {
+PipelinePtr Window::delete_pipeline(PipelineID pid) {
     render_sequence_->delete_pipeline(pid);
+    return nullptr;
 }
 
 bool Window::has_pipeline(PipelineID pid) const {

--- a/simulant/window.h
+++ b/simulant/window.h
@@ -190,7 +190,11 @@ public:
     virtual PipelinePtr pipeline(PipelineID pid) override;
     virtual bool enable_pipeline(PipelineID pid) override;
     virtual bool disable_pipeline(PipelineID pid) override;
-    virtual void delete_pipeline(PipelineID pid) override;
+
+    /* Delete a pipeline and return a nullptr so you can use the pattern
+     * pipeline_ = delete_pipeline(pipeline->id()) for safety
+     */
+    virtual PipelinePtr delete_pipeline(PipelineID pid) override;
     virtual bool has_pipeline(PipelineID pid) const override;
     virtual bool is_pipeline_enabled(PipelineID pid) const override;
 

--- a/tests/test_camera.h
+++ b/tests/test_camera.h
@@ -65,7 +65,7 @@ public:
     void test_camera_attached_to_parent_moves() {
         auto stage = window->new_stage().fetch();
 
-        auto actor = stage->new_actor().fetch();
+        auto actor = stage->new_actor();
         auto camera = stage->new_camera().fetch();
 
         auto od = camera->frustum().plane(FRUSTUM_PLANE_NEAR).d;

--- a/tests/test_camera.h
+++ b/tests/test_camera.h
@@ -14,14 +14,14 @@ class CameraTest : public SimulantTestCase {
 public:
     void set_up() {
         SimulantTestCase::set_up();
-        stage_id_ = window->new_stage();
-        camera_id_ = stage_id_.fetch()->new_camera();
+        stage_ = window->new_stage();
+        camera_id_ = stage_->new_camera();
     }
 
     void tear_down() {
         SimulantTestCase::tear_down();
-        stage_id_.fetch()->delete_camera(camera_id_);
-        window->delete_stage(stage_id_);
+        stage_->delete_camera(camera_id_);
+        window->delete_stage(stage_->id());
     }
 
     void test_project_point() {
@@ -42,31 +42,28 @@ public:
     void test_look_at() {       
         Vec3 pos(0, 0, -1);
 
-        auto stage = window->stage(stage_id_);
-        stage->camera(camera_id_)->look_at(pos);
+        stage_->camera(camera_id_)->look_at(pos);
 
-        Quaternion q = stage->camera(camera_id_)->absolute_rotation();
+        Quaternion q = stage_->camera(camera_id_)->absolute_rotation();
         assert_true(q == Quaternion());
 
         pos = Vec3(0, -1, 0);
-        stage->camera(camera_id_)->look_at(pos);
+        stage_->camera(camera_id_)->look_at(pos);
 
-        auto f = stage->camera(camera_id_)->forward();
+        auto f = stage_->camera(camera_id_)->forward();
         assert_close(0.0f, f.x, 0.000001);
         assert_close(-1.0f, f.y, 0.000001);
         assert_close(0.0f, f.z, 0.000001);
 
-        auto res = stage->camera(camera_id_)->up();
+        auto res = stage_->camera(camera_id_)->up();
         assert_close(res.x, 0, 0.000001);
         assert_close(res.y, 0, 0.000001);
         assert_close(res.z, 1, 0.000001);
     }
 
     void test_camera_attached_to_parent_moves() {
-        auto stage = window->new_stage().fetch();
-
-        auto actor = stage->new_actor();
-        auto camera = stage->new_camera().fetch();
+        auto actor = stage_->new_actor();
+        auto camera = stage_->new_camera().fetch();
 
         auto od = camera->frustum().plane(FRUSTUM_PLANE_NEAR).d;
 
@@ -82,7 +79,7 @@ public:
 
 private:
     CameraID camera_id_;
-    StageID stage_id_;
+    StagePtr stage_;
 };
 
 }

--- a/tests/test_camera.h
+++ b/tests/test_camera.h
@@ -15,17 +15,17 @@ public:
     void set_up() {
         SimulantTestCase::set_up();
         stage_ = window->new_stage();
-        camera_id_ = stage_->new_camera();
+        camera_ = stage_->new_camera();
     }
 
     void tear_down() {
         SimulantTestCase::tear_down();
-        stage_->delete_camera(camera_id_);
+        stage_->delete_camera(camera_->id());
         window->delete_stage(stage_->id());
     }
 
     void test_project_point() {
-        auto camera = camera_id_.fetch();
+        auto camera = camera_;
         camera->set_perspective_projection(Degrees(45.0), float(window->width()) / float(window->height()));
 
         Vec3 p1 = camera->project_point(*window, Viewport(), Vec3(0, 0, -10)).value();
@@ -42,20 +42,20 @@ public:
     void test_look_at() {       
         Vec3 pos(0, 0, -1);
 
-        stage_->camera(camera_id_)->look_at(pos);
+        camera_->look_at(pos);
 
-        Quaternion q = stage_->camera(camera_id_)->absolute_rotation();
+        Quaternion q = camera_->absolute_rotation();
         assert_true(q == Quaternion());
 
         pos = Vec3(0, -1, 0);
-        stage_->camera(camera_id_)->look_at(pos);
+        camera_->look_at(pos);
 
-        auto f = stage_->camera(camera_id_)->forward();
+        auto f = camera_->forward();
         assert_close(0.0f, f.x, 0.000001);
         assert_close(-1.0f, f.y, 0.000001);
         assert_close(0.0f, f.z, 0.000001);
 
-        auto res = stage_->camera(camera_id_)->up();
+        auto res = camera_->up();
         assert_close(res.x, 0, 0.000001);
         assert_close(res.y, 0, 0.000001);
         assert_close(res.z, 1, 0.000001);
@@ -63,7 +63,7 @@ public:
 
     void test_camera_attached_to_parent_moves() {
         auto actor = stage_->new_actor();
-        auto camera = stage_->new_camera().fetch();
+        auto camera = stage_->new_camera();
 
         auto od = camera->frustum().plane(FRUSTUM_PLANE_NEAR).d;
 
@@ -78,7 +78,7 @@ public:
     }
 
 private:
-    CameraID camera_id_;
+    CameraPtr camera_;
     StagePtr stage_;
 };
 

--- a/tests/test_controllers.h
+++ b/tests/test_controllers.h
@@ -25,7 +25,7 @@ class BehaviourTests : public SimulantTestCase {
 public:
     void test_behaviour_first_update() {
 
-        auto stage = window->new_stage().fetch();
+        auto stage = window->new_stage();
         auto actor = stage->new_actor();
 
         auto behaviour = actor->new_behaviour<TestBehaviour>();

--- a/tests/test_controllers.h
+++ b/tests/test_controllers.h
@@ -26,7 +26,7 @@ public:
     void test_behaviour_first_update() {
 
         auto stage = window->new_stage().fetch();
-        auto actor = stage->new_actor().fetch();
+        auto actor = stage->new_actor();
 
         auto behaviour = actor->new_behaviour<TestBehaviour>();
 

--- a/tests/test_mesh.h
+++ b/tests/test_mesh.h
@@ -16,12 +16,12 @@ public:
         SimulantTestCase::set_up();
 
         stage_ = window->new_stage();
-        camera_id_ = stage_->new_camera();
+        camera_ = stage_->new_camera();
     }
 
     void tear_down() {
         SimulantTestCase::tear_down();
-        stage_->delete_camera(camera_id_);
+        stage_->delete_camera(camera_->id());
         window->delete_stage(stage_->id());
     }
 
@@ -246,7 +246,7 @@ public:
     }
 
 private:
-    smlt::CameraID camera_id_;
+    smlt::CameraPtr camera_;
     smlt::StagePtr stage_;
 
     smlt::SubMesh* first_mesh_;

--- a/tests/test_mesh.h
+++ b/tests/test_mesh.h
@@ -103,8 +103,7 @@ public:
     void test_user_data_works() {
         auto stage = window->stage(stage_id_);
 
-        smlt::ActorID mid = stage->new_actor();
-        auto actor = stage->actor(mid);
+        auto actor = stage->new_actor();
 
         this->assert_true(actor->id() != 0); //Make sure we set an id for the mesh
         this->assert_true(actor->auto_id() != 0); //Make sure we set a unique ID for the object
@@ -113,26 +112,26 @@ public:
         this->assert_true(actor->data->exists("data"));
         this->assert_equal((int)0xDEADBEEF, actor->data->get<int>("data"));
 
-        stage->delete_actor(mid);
+        stage->delete_actor(actor->id());
 
-        this->assert_true(!stage->has_actor(mid));
+        this->assert_true(!stage->has_actor(actor->id()));
     }
 
     void test_deleting_entities_deletes_children() {
         auto stage = window->stage(stage_id_);
 
-        smlt::ActorID mid = stage->new_actor(); //Create the root mesh
-        smlt::ActorID cid1 = stage->new_actor_with_parent(mid); //Create a child
-        smlt::ActorID cid2 = stage->new_actor_with_parent(cid1); //Create a child of the child
+        auto mid = stage->new_actor(); //Create the root mesh
+        auto cid1 = stage->new_actor_with_parent(mid->id()); //Create a child
+        auto cid2 = stage->new_actor_with_parent(cid1->id()); //Create a child of the child
 
-        this->assert_equal((uint32_t)1, stage->actor(mid)->count_children());
-        this->assert_equal((uint32_t)1, stage->actor(cid1)->count_children());
-        this->assert_equal((uint32_t)0, stage->actor(cid2)->count_children());
+        this->assert_equal((uint32_t)1, mid->count_children());
+        this->assert_equal((uint32_t)1, cid1->count_children());
+        this->assert_equal((uint32_t)0, cid2->count_children());
 
-        stage->delete_actor(mid);
-        this->assert_true(!stage->has_actor(mid));
-        this->assert_true(!stage->has_actor(cid1));
-        this->assert_true(!stage->has_actor(cid2));
+        stage->delete_actor(mid->id());
+        this->assert_true(!stage->has_actor(mid->id()));
+        this->assert_true(!stage->has_actor(cid1->id()));
+        this->assert_true(!stage->has_actor(cid2->id()));
     }
 
     void test_basic_usage() {
@@ -159,7 +158,7 @@ public:
 
         auto mesh = stage->assets->mesh(generate_test_mesh(stage));
 
-        auto actor = stage->actor(stage->new_actor());
+        auto actor = stage->new_actor();
 
         assert_true(!actor->has_mesh());
 
@@ -192,7 +191,7 @@ public:
         auto stage = window->stage(stage_id_);
 
         smlt::MeshID mesh_id = stage->assets->new_mesh(smlt::VertexSpecification::POSITION_ONLY); //Create a mesh
-        auto actor = stage->actor(stage->new_actor_with_mesh(mesh_id));
+        auto actor = stage->new_actor_with_mesh(mesh_id);
 
         assert_true(mesh_id == actor->mesh()->id());
     }

--- a/tests/test_mesh_silhouette.h
+++ b/tests/test_mesh_silhouette.h
@@ -12,7 +12,7 @@ public:
     void test_directional_silhouette_generation() {
         auto stage = window->new_stage().fetch();
         auto mesh = stage->assets->new_mesh_as_rectangle(1.0f, 1.0f).fetch();
-        auto light = stage->new_light_as_directional().fetch();
+        auto light = stage->new_light_as_directional();
         light->move_to(0, 0, -10);
 
         MeshSilhouette silhouette(mesh, Mat4(), light);
@@ -22,7 +22,7 @@ public:
     void test_point_silhouette_generation() {
         auto stage = window->new_stage().fetch();
         auto mesh = stage->assets->new_mesh_as_rectangle(1.0f, 1.0f).fetch();
-        auto light = stage->new_light_as_point().fetch();
+        auto light = stage->new_light_as_point();
         light->move_to(0, 0, -10);
 
         MeshSilhouette silhouette(mesh, Mat4(), light);
@@ -32,7 +32,7 @@ public:
     void test_out_of_range_generates_none() {
         auto stage = window->new_stage().fetch();
         auto mesh = stage->assets->new_mesh_as_rectangle(1.0f, 1.0f).fetch();
-        auto light = stage->new_light_as_point().fetch();
+        auto light = stage->new_light_as_point();
         light->move_to(0, 0, -10);
         light->set_attenuation_from_range(5.0);
 

--- a/tests/test_mesh_silhouette.h
+++ b/tests/test_mesh_silhouette.h
@@ -10,7 +10,7 @@ using namespace smlt;
 class MeshSilhouetteTests : public SimulantTestCase {
 public:
     void test_directional_silhouette_generation() {
-        auto stage = window->new_stage().fetch();
+        auto stage = window->new_stage();
         auto mesh = stage->assets->new_mesh_as_rectangle(1.0f, 1.0f).fetch();
         auto light = stage->new_light_as_directional();
         light->move_to(0, 0, -10);
@@ -20,7 +20,7 @@ public:
     }
 
     void test_point_silhouette_generation() {
-        auto stage = window->new_stage().fetch();
+        auto stage = window->new_stage();
         auto mesh = stage->assets->new_mesh_as_rectangle(1.0f, 1.0f).fetch();
         auto light = stage->new_light_as_point();
         light->move_to(0, 0, -10);
@@ -30,7 +30,7 @@ public:
     }
 
     void test_out_of_range_generates_none() {
-        auto stage = window->new_stage().fetch();
+        auto stage = window->new_stage();
         auto mesh = stage->assets->new_mesh_as_rectangle(1.0f, 1.0f).fetch();
         auto light = stage->new_light_as_point();
         light->move_to(0, 0, -10);

--- a/tests/test_object.h
+++ b/tests/test_object.h
@@ -11,17 +11,17 @@ public:
     void set_up() {
         SimulantTestCase::set_up();
 
-        stage_id_ = window->new_stage();
-        camera_id_ = stage_id_.fetch()->new_camera();
+        stage_ = window->new_stage();
+        camera_id_ = stage_->new_camera();
     }
 
     void tear_down() {
         SimulantTestCase::tear_down();
-        window->delete_stage(stage_id_);
+        window->delete_stage(stage_->id());
     }
 
     void test_move_forward_by() {
-        auto actor = stage_id_.fetch()->new_actor();
+        auto actor = stage_->new_actor();
 
         actor->rotate_to(smlt::Quaternion(smlt::Degrees(0), smlt::Degrees(90), smlt::Degrees(0)));
         actor->move_forward_by(200);
@@ -34,7 +34,7 @@ public:
     void test_positional_constraints() {
         smlt::AABB aabb(Vec3(), 2.0);
 
-        auto actor = stage_id_.fetch()->new_actor();
+        auto actor = stage_->new_actor();
         actor->move_to(Vec3(2, 0.5, 0.5));
 
         assert_equal(2, actor->position().x);
@@ -49,7 +49,7 @@ public:
     }
 
     void test_scaling_applies() {
-        auto actor = window->stage(stage_id_)->new_actor();
+        auto actor = stage_->new_actor();
         actor->scale_by(smlt::Vec3(2.0, 1.0, 0.5));
 
         auto transform = actor->absolute_transformation();
@@ -58,7 +58,7 @@ public:
         assert_equal(transform[5], 1.0);
         assert_equal(transform[10], 0.5);
 
-        auto actor2 = window->stage(stage_id_)->new_actor();
+        auto actor2 = stage_->new_actor();
 
         actor2->rotate_y_by(smlt::Degrees(1.0));
 
@@ -74,8 +74,8 @@ public:
     }
 
     void test_set_parent() {
-        auto actor1 = window->stage(stage_id_)->new_actor();
-        auto actor2 = window->stage(stage_id_)->new_actor();
+        auto actor1 = stage_->new_actor();
+        auto actor2 = stage_->new_actor();
 
         actor2->set_parent(actor1);
 
@@ -91,8 +91,8 @@ public:
     }
 
     void test_parent_transformation_applied() {
-        auto actor1 = window->stage(stage_id_)->new_actor();
-        auto actor2 = window->stage(stage_id_)->new_actor();
+        auto actor1 = stage_->new_actor();
+        auto actor2 = stage_->new_actor();
         actor2->set_parent(actor1);
 
         actor2->move_to(smlt::Vec3(0, 0, -5));
@@ -106,13 +106,13 @@ public:
     }
 
     void test_set_absolute_rotation() {
-        auto actor = window->stage(stage_id_)->new_actor();
+        auto actor = stage_->new_actor();
 
         actor->rotate_to_absolute(smlt::Degrees(10), 0, 0, 1);
 
         assert_equal(actor->rotation(), actor->absolute_rotation());
 
-        auto actor2 = window->stage(stage_id_)->new_actor();
+        auto actor2 = stage_->new_actor();
 
         actor2->set_parent(actor->id());
 
@@ -135,13 +135,13 @@ public:
     }
 
     void test_set_absolute_position() {
-        auto actor = window->stage(stage_id_)->new_actor();
+        auto actor = stage_->new_actor();
 
         actor->move_to_absolute(10, 10, 10);
 
         assert_equal(smlt::Vec3(10, 10, 10), actor->absolute_position());
 
-        auto actor2 = window->stage(stage_id_)->new_actor();
+        auto actor2 = stage_->new_actor();
 
         actor2->set_parent(actor->id());
 
@@ -159,7 +159,7 @@ public:
     }
 
     void test_set_relative_position() {
-        auto actor = window->stage(stage_id_)->new_actor();
+        auto actor = stage_->new_actor();
 
         actor->move_to(10, 10, 10);
 
@@ -167,7 +167,7 @@ public:
         assert_equal(smlt::Vec3(10, 10, 10), actor->position());
         assert_equal(smlt::Vec3(10, 10, 10), actor->absolute_position());
 
-        auto actor2 = window->stage(stage_id_)->new_actor();
+        auto actor2 = stage_->new_actor();
 
         actor2->set_parent(actor->id());
 
@@ -178,10 +178,8 @@ public:
     }
 
     void test_move_updates_children() {
-        auto stage = stage_id_.fetch();
-
-        auto actor1 = stage->new_actor();
-        auto actor2 = stage->new_actor();
+        auto actor1 = stage_->new_actor();
+        auto actor2 = stage_->new_actor();
 
         actor2->move_to(0, 0, 10.0f);
         actor2->set_parent(actor1);
@@ -190,8 +188,7 @@ public:
     }
 
     void test_set_parent_to_self_does_nothing() {
-        auto stage = stage_id_.fetch();
-        auto actor1 = stage->new_actor();
+        auto actor1 = stage_->new_actor();
 
         auto original_parent = actor1->parent();
         actor1->set_parent(actor1);
@@ -200,7 +197,7 @@ public:
 
 private:
     smlt::CameraID camera_id_;
-    smlt::StageID stage_id_;
+    smlt::StagePtr stage_;
 };
 
 #endif // TEST_OBJECT_H

--- a/tests/test_object.h
+++ b/tests/test_object.h
@@ -21,7 +21,7 @@ public:
     }
 
     void test_move_forward_by() {
-        auto actor = stage_id_.fetch()->new_actor().fetch();
+        auto actor = stage_id_.fetch()->new_actor();
 
         actor->rotate_to(smlt::Quaternion(smlt::Degrees(0), smlt::Degrees(90), smlt::Degrees(0)));
         actor->move_forward_by(200);
@@ -34,7 +34,7 @@ public:
     void test_positional_constraints() {
         smlt::AABB aabb(Vec3(), 2.0);
 
-        auto actor = stage_id_.fetch()->new_actor().fetch();
+        auto actor = stage_id_.fetch()->new_actor();
         actor->move_to(Vec3(2, 0.5, 0.5));
 
         assert_equal(2, actor->position().x);
@@ -49,7 +49,7 @@ public:
     }
 
     void test_scaling_applies() {
-        auto actor = window->stage(stage_id_)->new_actor().fetch();
+        auto actor = window->stage(stage_id_)->new_actor();
         actor->scale_by(smlt::Vec3(2.0, 1.0, 0.5));
 
         auto transform = actor->absolute_transformation();
@@ -58,7 +58,7 @@ public:
         assert_equal(transform[5], 1.0);
         assert_equal(transform[10], 0.5);
 
-        auto actor2 = window->stage(stage_id_)->new_actor().fetch();
+        auto actor2 = window->stage(stage_id_)->new_actor();
 
         actor2->rotate_y_by(smlt::Degrees(1.0));
 
@@ -74,8 +74,8 @@ public:
     }
 
     void test_set_parent() {
-        auto actor1 = window->stage(stage_id_)->new_actor().fetch();
-        auto actor2 = window->stage(stage_id_)->new_actor().fetch();
+        auto actor1 = window->stage(stage_id_)->new_actor();
+        auto actor2 = window->stage(stage_id_)->new_actor();
 
         actor2->set_parent(actor1);
 
@@ -91,8 +91,8 @@ public:
     }
 
     void test_parent_transformation_applied() {
-        auto actor1 = window->stage(stage_id_)->new_actor().fetch();
-        auto actor2 = window->stage(stage_id_)->new_actor().fetch();
+        auto actor1 = window->stage(stage_id_)->new_actor();
+        auto actor2 = window->stage(stage_id_)->new_actor();
         actor2->set_parent(actor1);
 
         actor2->move_to(smlt::Vec3(0, 0, -5));
@@ -106,17 +106,15 @@ public:
     }
 
     void test_set_absolute_rotation() {
-        smlt::ActorID act = window->stage(stage_id_)->new_actor();
-        auto actor = window->stage(stage_id_)->actor(act);
+        auto actor = window->stage(stage_id_)->new_actor();
 
         actor->rotate_to_absolute(smlt::Degrees(10), 0, 0, 1);
 
         assert_equal(actor->rotation(), actor->absolute_rotation());
 
-        smlt::ActorID act2 = window->stage(stage_id_)->new_actor();
-        auto actor2 = window->stage(stage_id_)->actor(act2);
+        auto actor2 = window->stage(stage_id_)->new_actor();
 
-        actor2->set_parent(act);
+        actor2->set_parent(actor->id());
 
         assert_equal(actor2->absolute_rotation(), actor->absolute_rotation());
 
@@ -137,17 +135,15 @@ public:
     }
 
     void test_set_absolute_position() {
-        smlt::ActorID act = window->stage(stage_id_)->new_actor();
-        auto actor = window->stage(stage_id_)->actor(act);
+        auto actor = window->stage(stage_id_)->new_actor();
 
         actor->move_to_absolute(10, 10, 10);
 
         assert_equal(smlt::Vec3(10, 10, 10), actor->absolute_position());
 
-        smlt::ActorID act2 = window->stage(stage_id_)->new_actor();
-        auto actor2 = window->stage(stage_id_)->actor(act2);
+        auto actor2 = window->stage(stage_id_)->new_actor();
 
-        actor2->set_parent(act);
+        actor2->set_parent(actor->id());
 
         //Should be the same as its parent
         assert_equal(actor2->absolute_position(), actor->absolute_position());
@@ -163,8 +159,7 @@ public:
     }
 
     void test_set_relative_position() {
-        smlt::ActorID act = window->stage(stage_id_)->new_actor();
-        auto actor = window->stage(stage_id_)->actor(act);
+        auto actor = window->stage(stage_id_)->new_actor();
 
         actor->move_to(10, 10, 10);
 
@@ -172,10 +167,9 @@ public:
         assert_equal(smlt::Vec3(10, 10, 10), actor->position());
         assert_equal(smlt::Vec3(10, 10, 10), actor->absolute_position());
 
-        smlt::ActorID act2 = window->stage(stage_id_)->new_actor();
-        auto actor2 = window->stage(stage_id_)->actor(act2);
+        auto actor2 = window->stage(stage_id_)->new_actor();
 
-        actor2->set_parent(act);
+        actor2->set_parent(actor->id());
 
         actor2->move_to(smlt::Vec3(10, 0, 0));
 
@@ -186,8 +180,8 @@ public:
     void test_move_updates_children() {
         auto stage = stage_id_.fetch();
 
-        auto actor1 = stage->new_actor().fetch();
-        auto actor2 = stage->new_actor().fetch();
+        auto actor1 = stage->new_actor();
+        auto actor2 = stage->new_actor();
 
         actor2->move_to(0, 0, 10.0f);
         actor2->set_parent(actor1);
@@ -197,7 +191,7 @@ public:
 
     void test_set_parent_to_self_does_nothing() {
         auto stage = stage_id_.fetch();
-        auto actor1 = stage->new_actor().fetch();
+        auto actor1 = stage->new_actor();
 
         auto original_parent = actor1->parent();
         actor1->set_parent(actor1);

--- a/tests/test_object.h
+++ b/tests/test_object.h
@@ -12,7 +12,7 @@ public:
         SimulantTestCase::set_up();
 
         stage_ = window->new_stage();
-        camera_id_ = stage_->new_camera();
+        camera_ = stage_->new_camera();
     }
 
     void tear_down() {
@@ -196,7 +196,7 @@ public:
     }
 
 private:
-    smlt::CameraID camera_id_;
+    smlt::CameraPtr camera_;
     smlt::StagePtr stage_;
 };
 

--- a/tests/test_partitioner.h
+++ b/tests/test_partitioner.h
@@ -122,10 +122,10 @@ public:
         };
 
         StagePtr stage = window->new_stage().fetch();
-        ParticleSystemID ps = stage->new_particle_system();
+        auto ps = stage->new_particle_system();
 
         MockPartitioner partitioner(stage, test);
-        partitioner.add_particle_system(ps);
+        partitioner.add_particle_system(ps->id());
         partitioner._apply_writes();
 
         window->delete_stage(stage->id());
@@ -142,10 +142,10 @@ public:
         };
 
         StagePtr stage = window->new_stage().fetch();
-        ParticleSystemID ps = stage->new_particle_system();
+        auto ps = stage->new_particle_system();
 
         MockPartitioner partitioner(stage, test);
-        partitioner.remove_particle_system(ps);
+        partitioner.remove_particle_system(ps->id());
         partitioner._apply_writes();
         window->delete_stage(stage->id());
     }

--- a/tests/test_partitioner.h
+++ b/tests/test_partitioner.h
@@ -41,7 +41,7 @@ public:
             assert_false(write.geom_id);
         };
 
-        StagePtr stage = window->new_stage().fetch();
+        StagePtr stage = window->new_stage();
         ActorPtr actor = stage->new_actor();
 
         MockPartitioner partitioner(stage, test);
@@ -61,7 +61,7 @@ public:
             assert_false(write.geom_id);
         };
 
-        StagePtr stage = window->new_stage().fetch();
+        StagePtr stage = window->new_stage();
         ActorPtr actor = stage->new_actor();
 
         MockPartitioner partitioner(stage, test);
@@ -81,7 +81,7 @@ public:
             assert_false(write.geom_id);
         };
 
-        StagePtr stage = window->new_stage().fetch();
+        StagePtr stage = window->new_stage();
         auto light = stage->new_light_as_point();
 
         MockPartitioner partitioner(stage, test);
@@ -101,7 +101,7 @@ public:
             assert_false(write.geom_id);
         };
 
-        StagePtr stage = window->new_stage().fetch();
+        StagePtr stage = window->new_stage();
         auto light = stage->new_light_as_point();
 
         MockPartitioner partitioner(stage, test);
@@ -121,7 +121,7 @@ public:
             assert_false(write.geom_id);
         };
 
-        StagePtr stage = window->new_stage().fetch();
+        StagePtr stage = window->new_stage();
         auto ps = stage->new_particle_system();
 
         MockPartitioner partitioner(stage, test);
@@ -141,7 +141,7 @@ public:
             assert_false(write.geom_id);
         };
 
-        StagePtr stage = window->new_stage().fetch();
+        StagePtr stage = window->new_stage();
         auto ps = stage->new_particle_system();
 
         MockPartitioner partitioner(stage, test);

--- a/tests/test_partitioner.h
+++ b/tests/test_partitioner.h
@@ -42,10 +42,10 @@ public:
         };
 
         StagePtr stage = window->new_stage().fetch();
-        ActorID actor = stage->new_actor();
+        ActorPtr actor = stage->new_actor();
 
         MockPartitioner partitioner(stage, test);
-        partitioner.add_actor(actor);
+        partitioner.add_actor(actor->id());
         partitioner._apply_writes();
 
         window->delete_stage(stage->id());
@@ -62,10 +62,10 @@ public:
         };
 
         StagePtr stage = window->new_stage().fetch();
-        ActorID actor = stage->new_actor();
+        ActorPtr actor = stage->new_actor();
 
         MockPartitioner partitioner(stage, test);
-        partitioner.remove_actor(actor);
+        partitioner.remove_actor(actor->id());
         partitioner._apply_writes();
 
         window->delete_stage(stage->id());

--- a/tests/test_partitioner.h
+++ b/tests/test_partitioner.h
@@ -82,10 +82,10 @@ public:
         };
 
         StagePtr stage = window->new_stage().fetch();
-        LightID light = stage->new_light_as_point();
+        auto light = stage->new_light_as_point();
 
         MockPartitioner partitioner(stage, test);
-        partitioner.add_light(light);
+        partitioner.add_light(light->id());
         partitioner._apply_writes();
 
         window->delete_stage(stage->id());
@@ -102,10 +102,10 @@ public:
         };
 
         StagePtr stage = window->new_stage().fetch();
-        LightID light = stage->new_light_as_point();
+        auto light = stage->new_light_as_point();
 
         MockPartitioner partitioner(stage, test);
-        partitioner.remove_light(light);
+        partitioner.remove_light(light->id());
         partitioner._apply_writes();
 
         window->delete_stage(stage->id());

--- a/tests/test_physics.h
+++ b/tests/test_physics.h
@@ -54,7 +54,7 @@ public:
     }
 
     void test_box_collider_addition() {
-        auto actor1 = stage->new_actor().fetch();
+        auto actor1 = stage->new_actor();
 
         auto body = actor1->new_behaviour<behaviours::RigidBody>(physics.get());
 
@@ -82,7 +82,7 @@ public:
     }
 
     void test_sphere_collider_addition() {
-        auto actor1 = stage->new_actor().fetch();
+        auto actor1 = stage->new_actor();
 
         auto body = actor1->new_behaviour<behaviours::RigidBody>(physics.get());
         body->add_sphere_collider(2.0, behaviours::PhysicsMaterial::WOOD);
@@ -96,7 +96,7 @@ public:
 
     void test_mesh_collider_addition() {
         auto mesh_id = stage->assets->new_mesh_as_box(1.0, 1.0, 1.0);
-        auto actor1 = stage->new_actor().fetch();
+        auto actor1 = stage->new_actor();
         auto body = actor1->new_behaviour<behaviours::StaticBody>(physics.get());
         body->add_mesh_collider(mesh_id, behaviours::PhysicsMaterial::WOOD);
 
@@ -115,13 +115,13 @@ public:
         Listener listener(&enter_called, nullptr, &leave_called);
 
         // Create body A
-        auto actor1 = stage->new_actor().fetch();
+        auto actor1 = stage->new_actor();
         auto body = actor1->new_behaviour<behaviours::StaticBody>(physics.get());
         body->add_box_collider(Vec3(1, 1, 1), behaviours::PhysicsMaterial::WOOD);
         body->register_collision_listener(&listener); // Register the listener
 
         // Create overlapping body B!
-        auto actor2 = stage->new_actor().fetch();
+        auto actor2 = stage->new_actor();
         auto body2 = actor2->new_behaviour<behaviours::RigidBody>(physics.get());
         body2->add_box_collider(Vec3(1, 1, 1), behaviours::PhysicsMaterial::WOOD);
 
@@ -162,12 +162,12 @@ public:
 
         Listener listener(&enter_called, nullptr, &leave_called);
 
-        auto actor1 = stage->new_actor().fetch();
+        auto actor1 = stage->new_actor();
         auto body = actor1->new_behaviour<behaviours::StaticBody>(physics.get());
         body->add_box_collider(Vec3(1, 1, 1), behaviours::PhysicsMaterial::WOOD);
         body->register_collision_listener(&listener);
 
-        auto actor2 = stage->new_actor().fetch();
+        auto actor2 = stage->new_actor();
         auto body2 = actor2->new_behaviour<behaviours::RigidBody>(physics.get());
         body2->add_box_collider(Vec3(1, 1, 1), behaviours::PhysicsMaterial::WOOD);
 
@@ -190,12 +190,12 @@ public:
 
         Listener listener(nullptr, &stay_count, nullptr);
 
-        auto actor1 = stage->new_actor().fetch();
+        auto actor1 = stage->new_actor();
         auto body = actor1->new_behaviour<behaviours::StaticBody>(physics.get());
         body->add_box_collider(Vec3(1, 1, 1), behaviours::PhysicsMaterial::WOOD);
         body->register_collision_listener(&listener);
 
-        auto actor2 = stage->new_actor().fetch();
+        auto actor2 = stage->new_actor();
         auto body2 = actor2->new_behaviour<behaviours::RigidBody>(physics.get());
         body2->add_box_collider(Vec3(1, 1, 1), behaviours::PhysicsMaterial::WOOD);
 

--- a/tests/test_physics.h
+++ b/tests/test_physics.h
@@ -44,7 +44,7 @@ public:
 
         physics = behaviours::RigidBodySimulation::create(window->time_keeper);
         physics->set_gravity(Vec3());
-        stage = window->new_stage().fetch();
+        stage = window->new_stage();
     }
 
     void tear_down() {

--- a/tests/test_render_chain.h
+++ b/tests/test_render_chain.h
@@ -14,36 +14,36 @@ class RenderChainTests : public SimulantTestCase {
 public:
     void test_basic_usage() {
         Viewport view;
-        StageID stage = window->new_stage();
-        CameraID cam = stage.fetch()->new_camera();
+        auto stage = window->new_stage();
+        CameraID cam = stage->new_camera();
         TextureID tex = window->shared_assets->new_texture();
 
-        PipelineID pid1 = window->render(stage, cam);
-        PipelineID pid2 = window->render(stage, cam).to_texture(tex);
-        PipelineID pid3 = window->render(stage, cam).to_framebuffer(view);
-        PipelineID pid4 = window->render(stage, cam).with_priority(RENDER_PRIORITY_FOREGROUND);
+        PipelineID pid1 = window->render(stage->id(), cam);
+        PipelineID pid2 = window->render(stage->id(), cam).to_texture(tex);
+        PipelineID pid3 = window->render(stage->id(), cam).to_framebuffer(view);
+        PipelineID pid4 = window->render(stage->id(), cam).with_priority(RENDER_PRIORITY_FOREGROUND);
 
         auto pipeline1 = window->pipeline(pid1);
         assert_equal(cam, pipeline1->camera_id());
-        assert_equal(stage, pipeline1->stage_id());
+        assert_equal(stage->id(), pipeline1->stage_id());
         assert_equal(TextureID(), pipeline1->target_id());
         assert_equal(RENDER_PRIORITY_MAIN, pipeline1->priority());
 
         auto pipeline2 = window->pipeline(pid2);
         assert_equal(cam, pipeline2->camera_id());
-        assert_equal(stage, pipeline2->stage_id());
+        assert_equal(stage->id(), pipeline2->stage_id());
         assert_equal(tex, pipeline2->target_id());
         assert_equal(RENDER_PRIORITY_MAIN, pipeline2->priority());
 
         auto pipeline3 = window->pipeline(pid3);
         assert_equal(cam, pipeline3->camera_id());
-        assert_equal(stage, pipeline3->stage_id());
+        assert_equal(stage->id(), pipeline3->stage_id());
         assert_equal(TextureID(), pipeline3->target_id());
         assert_equal(RENDER_PRIORITY_MAIN, pipeline3->priority());
 
         auto pipeline4 = window->pipeline(pid4);
         assert_equal(cam, pipeline4->camera_id());
-        assert_equal(stage, pipeline4->stage_id());
+        assert_equal(stage->id(), pipeline4->stage_id());
         assert_equal(TextureID(), pipeline4->target_id());
         assert_equal(RENDER_PRIORITY_FOREGROUND, pipeline4->priority());
 
@@ -59,34 +59,34 @@ public:
     }
 
     void test_rendering_flag() {
-        StageID stage = window->new_stage();
-        CameraID cam = stage.fetch()->new_camera();
+        auto stage = window->new_stage();
+        CameraID cam = stage->new_camera();
 
-        assert_false(window->stage(stage)->is_being_rendered());
+        assert_false(stage->is_being_rendered());
 
-        PipelineID pid1 = window->render(stage, cam);
+        PipelineID pid1 = window->render(stage->id(), cam);
 
-        assert_true(window->stage(stage)->is_being_rendered());
+        assert_true(stage->is_being_rendered());
 
         window->disable_pipeline(pid1);
 
-        assert_false(window->stage(stage)->is_being_rendered());
+        assert_false(stage->is_being_rendered());
 
-        PipelineID pid2 = window->render(stage, cam);
+        PipelineID pid2 = window->render(stage->id(), cam);
 
-        assert_true(window->stage(stage)->is_being_rendered());
+        assert_true(stage->is_being_rendered());
 
         window->delete_pipeline(pid2);
 
-        assert_false(window->stage(stage)->is_being_rendered());
+        assert_false(stage->is_being_rendered());
 
         window->enable_pipeline(pid1);
 
-        assert_true(window->stage(stage)->is_being_rendered());
+        assert_true(stage->is_being_rendered());
 
         window->delete_pipeline(pid1);
 
-        assert_false(window->stage(stage)->is_being_rendered());
+        assert_false(stage->is_being_rendered());
     }
 };
 

--- a/tests/test_render_chain.h
+++ b/tests/test_render_chain.h
@@ -18,44 +18,41 @@ public:
         auto cam = stage->new_camera();
         TextureID tex = window->shared_assets->new_texture();
 
-        PipelineID pid1 = window->render(stage, cam);
-        PipelineID pid2 = window->render(stage, cam).to_texture(tex);
-        PipelineID pid3 = window->render(stage, cam).to_framebuffer(view);
-        PipelineID pid4 = window->render(stage, cam).with_priority(RENDER_PRIORITY_FOREGROUND);
+        PipelinePtr pipeline1 = window->render(stage, cam);
+        PipelinePtr pipeline2 = window->render(stage, cam).to_texture(tex);
+        PipelinePtr pipeline3 = window->render(stage, cam).to_framebuffer(view);
+        PipelinePtr pipeline4 = window->render(stage, cam).with_priority(RENDER_PRIORITY_FOREGROUND);
 
-        auto pipeline1 = window->pipeline(pid1);
         assert_equal(cam->id(), pipeline1->camera_id());
         assert_equal(stage->id(), pipeline1->stage_id());
         assert_equal(TextureID(), pipeline1->target_id());
         assert_equal(RENDER_PRIORITY_MAIN, pipeline1->priority());
 
-        auto pipeline2 = window->pipeline(pid2);
         assert_equal(cam->id(), pipeline2->camera_id());
         assert_equal(stage->id(), pipeline2->stage_id());
         assert_equal(tex, pipeline2->target_id());
         assert_equal(RENDER_PRIORITY_MAIN, pipeline2->priority());
 
-        auto pipeline3 = window->pipeline(pid3);
         assert_equal(cam->id(), pipeline3->camera_id());
         assert_equal(stage->id(), pipeline3->stage_id());
         assert_equal(TextureID(), pipeline3->target_id());
         assert_equal(RENDER_PRIORITY_MAIN, pipeline3->priority());
 
-        auto pipeline4 = window->pipeline(pid4);
         assert_equal(cam->id(), pipeline4->camera_id());
         assert_equal(stage->id(), pipeline4->stage_id());
         assert_equal(TextureID(), pipeline4->target_id());
         assert_equal(RENDER_PRIORITY_FOREGROUND, pipeline4->priority());
 
-        window->disable_pipeline(pid1);
+        pipeline1->deactivate();
 
-        assert_false(window->is_pipeline_enabled(pid1));
+        assert_false(window->is_pipeline_enabled(pipeline1->id()));
 
+        auto pid2 = pipeline2->id();
         window->delete_pipeline(pid2);
         assert_false(window->has_pipeline(pid2));
 
-        window->enable_pipeline(pid1);
-        assert_true(window->is_pipeline_enabled(pid1));
+        pipeline1->activate();
+        assert_true(window->is_pipeline_enabled(pipeline1->id()));
     }
 
     void test_rendering_flag() {
@@ -64,27 +61,27 @@ public:
 
         assert_false(stage->is_being_rendered());
 
-        PipelineID pid1 = window->render(stage, cam);
+        PipelinePtr pipeline = window->render(stage, cam);
 
         assert_true(stage->is_being_rendered());
 
-        window->disable_pipeline(pid1);
+        pipeline->deactivate();
 
         assert_false(stage->is_being_rendered());
 
-        PipelineID pid2 = window->render(stage, cam);
+        PipelinePtr pipeline2 = window->render(stage, cam);
 
         assert_true(stage->is_being_rendered());
 
-        window->delete_pipeline(pid2);
+        window->delete_pipeline(pipeline2->id());
 
         assert_false(stage->is_being_rendered());
 
-        window->enable_pipeline(pid1);
+        pipeline->activate();
 
         assert_true(stage->is_being_rendered());
 
-        window->delete_pipeline(pid1);
+        window->delete_pipeline(pipeline->id());
 
         assert_false(stage->is_being_rendered());
     }

--- a/tests/test_render_chain.h
+++ b/tests/test_render_chain.h
@@ -15,34 +15,34 @@ public:
     void test_basic_usage() {
         Viewport view;
         auto stage = window->new_stage();
-        CameraID cam = stage->new_camera();
+        auto cam = stage->new_camera();
         TextureID tex = window->shared_assets->new_texture();
 
-        PipelineID pid1 = window->render(stage->id(), cam);
-        PipelineID pid2 = window->render(stage->id(), cam).to_texture(tex);
-        PipelineID pid3 = window->render(stage->id(), cam).to_framebuffer(view);
-        PipelineID pid4 = window->render(stage->id(), cam).with_priority(RENDER_PRIORITY_FOREGROUND);
+        PipelineID pid1 = window->render(stage, cam);
+        PipelineID pid2 = window->render(stage, cam).to_texture(tex);
+        PipelineID pid3 = window->render(stage, cam).to_framebuffer(view);
+        PipelineID pid4 = window->render(stage, cam).with_priority(RENDER_PRIORITY_FOREGROUND);
 
         auto pipeline1 = window->pipeline(pid1);
-        assert_equal(cam, pipeline1->camera_id());
+        assert_equal(cam->id(), pipeline1->camera_id());
         assert_equal(stage->id(), pipeline1->stage_id());
         assert_equal(TextureID(), pipeline1->target_id());
         assert_equal(RENDER_PRIORITY_MAIN, pipeline1->priority());
 
         auto pipeline2 = window->pipeline(pid2);
-        assert_equal(cam, pipeline2->camera_id());
+        assert_equal(cam->id(), pipeline2->camera_id());
         assert_equal(stage->id(), pipeline2->stage_id());
         assert_equal(tex, pipeline2->target_id());
         assert_equal(RENDER_PRIORITY_MAIN, pipeline2->priority());
 
         auto pipeline3 = window->pipeline(pid3);
-        assert_equal(cam, pipeline3->camera_id());
+        assert_equal(cam->id(), pipeline3->camera_id());
         assert_equal(stage->id(), pipeline3->stage_id());
         assert_equal(TextureID(), pipeline3->target_id());
         assert_equal(RENDER_PRIORITY_MAIN, pipeline3->priority());
 
         auto pipeline4 = window->pipeline(pid4);
-        assert_equal(cam, pipeline4->camera_id());
+        assert_equal(cam->id(), pipeline4->camera_id());
         assert_equal(stage->id(), pipeline4->stage_id());
         assert_equal(TextureID(), pipeline4->target_id());
         assert_equal(RENDER_PRIORITY_FOREGROUND, pipeline4->priority());
@@ -60,11 +60,11 @@ public:
 
     void test_rendering_flag() {
         auto stage = window->new_stage();
-        CameraID cam = stage->new_camera();
+        auto cam = stage->new_camera();
 
         assert_false(stage->is_being_rendered());
 
-        PipelineID pid1 = window->render(stage->id(), cam);
+        PipelineID pid1 = window->render(stage, cam);
 
         assert_true(stage->is_being_rendered());
 
@@ -72,7 +72,7 @@ public:
 
         assert_false(stage->is_being_rendered());
 
-        PipelineID pid2 = window->render(stage->id(), cam);
+        PipelineID pid2 = window->render(stage, cam);
 
         assert_true(stage->is_being_rendered());
 

--- a/tests/test_render_queue.h
+++ b/tests/test_render_queue.h
@@ -37,7 +37,7 @@ public:
         auto mesh_1 = stage_->assets->new_mesh_as_cube(1.0);
         stage_->assets->mesh(mesh_1)->set_material_id(mat_1);
 
-        auto actor_id = stage_->new_actor_with_mesh(mesh_1);
+        auto actor = stage_->new_actor_with_mesh(mesh_1);
 
         assert_equal(1u, render_queue->pass_count());
 
@@ -54,7 +54,7 @@ public:
         // in the render queue, and because the texture ID is higher, then this should make
         // the new group > the old one.
 
-        stage_->actor(actor_id)->override_material_id(mat_2);
+        actor->override_material_id(mat_2);
 
         assert_equal(1u, render_queue->group_count(0));
 
@@ -62,7 +62,7 @@ public:
              assert_true(*group < grp);
         });
 
-        stage_->actor(actor_id)->remove_material_id_override();
+        actor->remove_material_id_override();
         stage_->assets->mesh(mesh_1)->set_material_id(mat_1);
 
         assert_equal(1u, render_queue->group_count(0));
@@ -86,7 +86,7 @@ public:
         auto& render_queue = stage_->render_queue;
 
         auto mesh_1 = stage_->assets->new_mesh_as_cube(1.0);
-        auto actor_id = stage_->new_actor_with_mesh(mesh_1);
+        auto actor = stage_->new_actor_with_mesh(mesh_1);
 
 #ifdef SIMULANT_GL_VERSION_1X
         assert_equal(1u, render_queue->pass_count());
@@ -96,7 +96,7 @@ public:
         assert_equal(1u, render_queue->group_count(0));
         assert_equal(1u, render_queue->group_count(1));
 #endif
-        stage_->delete_actor(actor_id);
+        stage_->delete_actor(actor->id());
 
         assert_equal(0u, render_queue->pass_count());
     }

--- a/tests/test_render_queue.h
+++ b/tests/test_render_queue.h
@@ -12,7 +12,7 @@ class RenderQueueTests : public SimulantTestCase {
 public:
     void set_up() {
         SimulantTestCase::set_up();
-        stage_ = window->stage(window->new_stage());
+        stage_ = window->new_stage();
     }
 
     void tear_down() {

--- a/tests/test_rigid_body.h
+++ b/tests/test_rigid_body.h
@@ -8,7 +8,7 @@
 class RigidBodyTest : public SimulantTestCase {
 public:
     void test_adding_to_stage_node_inherits_location() {
-        smlt::StagePtr stage = window->new_stage().fetch();
+        smlt::StagePtr stage = window->new_stage();
         smlt::ActorPtr actor = stage->new_actor();
 
         actor->move_to(10, 0, 0);

--- a/tests/test_rigid_body.h
+++ b/tests/test_rigid_body.h
@@ -9,7 +9,7 @@ class RigidBodyTest : public SimulantTestCase {
 public:
     void test_adding_to_stage_node_inherits_location() {
         smlt::StagePtr stage = window->new_stage().fetch();
-        smlt::ActorPtr actor = stage->new_actor().fetch();
+        smlt::ActorPtr actor = stage->new_actor();
 
         actor->move_to(10, 0, 0);
         actor->rotate_x_by(smlt::Degrees(90));

--- a/tests/test_skybox.h
+++ b/tests/test_skybox.h
@@ -11,7 +11,7 @@ public:
     void test_skybox_from_folder() {
         auto stage = window->new_stage();
 
-        auto sky = stage->skies->new_skybox_from_folder("skyboxes/TropicalSunnyDay").fetch_as<Skybox>();
+        auto sky = stage->skies->new_skybox_from_folder("skyboxes/TropicalSunnyDay");
 
         assert_equal(sky->count_children(), 1u); // Should have 1 child (the actor)
     }

--- a/tests/test_skybox.h
+++ b/tests/test_skybox.h
@@ -9,7 +9,7 @@ using namespace smlt;
 class SkyboxTest : public SimulantTestCase {
 public:
     void test_skybox_from_folder() {
-        auto stage = window->new_stage().fetch();
+        auto stage = window->new_stage();
 
         auto sky = stage->skies->new_skybox_from_folder("skyboxes/TropicalSunnyDay").fetch_as<Skybox>();
 

--- a/tests/test_smooth_follow.h
+++ b/tests/test_smooth_follow.h
@@ -16,7 +16,7 @@ public:
         SimulantTestCase::set_up();
 
         stage = window->new_stage().fetch();
-        actor = stage->new_actor().fetch();
+        actor = stage->new_actor();
     }
 
     void tear_down() {
@@ -27,7 +27,7 @@ public:
 
 
     void test_half_turn() {
-        auto follower = stage->new_actor().fetch();
+        auto follower = stage->new_actor();
         auto controller = follower->new_behaviour<smlt::behaviours::SmoothFollow>();
         controller->set_target(actor);
         controller->set_follow_height(0);

--- a/tests/test_smooth_follow.h
+++ b/tests/test_smooth_follow.h
@@ -15,7 +15,7 @@ public:
     void set_up() {
         SimulantTestCase::set_up();
 
-        stage = window->new_stage().fetch();
+        stage = window->new_stage();
         actor = stage->new_actor();
     }
 

--- a/tests/test_sound.h
+++ b/tests/test_sound.h
@@ -18,12 +18,11 @@ public:
         SimulantTestCase::set_up();
 
         stage_ = window->new_stage();
-        camera_id_ = stage_->new_camera();
+        camera_ = stage_->new_camera();
     }
 
     void tear_down() {
         SimulantTestCase::tear_down();
-        stage_->delete_camera(camera_id_);
         window->delete_stage(stage_->id());
     }
 
@@ -60,7 +59,7 @@ public:
     }
 
 private:
-    smlt::CameraID camera_id_;
+    smlt::CameraPtr camera_;
     smlt::StagePtr stage_;
 
 };

--- a/tests/test_sound.h
+++ b/tests/test_sound.h
@@ -46,7 +46,7 @@ public:
 
         smlt::SoundID sound = stage->assets->new_sound_from_file("test_sound.ogg");
 
-        auto actor = stage->actor(stage->new_actor());
+        auto actor = stage->new_actor();
         actor->move_to(10, 0, 0);
 
         assert_false(actor->playing_sound_count());

--- a/tests/test_sound.h
+++ b/tests/test_sound.h
@@ -17,14 +17,14 @@ public:
 
         SimulantTestCase::set_up();
 
-        stage_id_ = window->new_stage();
-        camera_id_ = stage_id_.fetch()->new_camera();
+        stage_ = window->new_stage();
+        camera_id_ = stage_->new_camera();
     }
 
     void tear_down() {
         SimulantTestCase::tear_down();
-        stage_id_.fetch()->delete_camera(camera_id_);
-        window->delete_stage(stage_id_);
+        stage_->delete_camera(camera_id_);
+        window->delete_stage(stage_->id());
     }
 
     void test_2d_sound_output() {
@@ -42,11 +42,9 @@ public:
     }
 
     void test_3d_sound_output() {
-        auto stage = window->stage(stage_id_);
+        smlt::SoundID sound = stage_->assets->new_sound_from_file("test_sound.ogg");
 
-        smlt::SoundID sound = stage->assets->new_sound_from_file("test_sound.ogg");
-
-        auto actor = stage->new_actor();
+        auto actor = stage_->new_actor();
         actor->move_to(10, 0, 0);
 
         assert_false(actor->playing_sound_count());
@@ -63,7 +61,7 @@ public:
 
 private:
     smlt::CameraID camera_id_;
-    smlt::StageID stage_id_;
+    smlt::StagePtr stage_;
 
 };
 #endif // TEST_SOUND_H

--- a/tests/test_sprites.h
+++ b/tests/test_sprites.h
@@ -7,7 +7,7 @@ namespace {
 class SpriteTests : public SimulantTestCase {
 public:
     void test_set_alpha() {
-        auto stage = window->new_stage().fetch();
+        auto stage = window->new_stage();
         auto sprite = stage->sprites->new_sprite().fetch();
 
         sprite->set_alpha(0.5f);

--- a/tests/test_sprites.h
+++ b/tests/test_sprites.h
@@ -8,7 +8,7 @@ class SpriteTests : public SimulantTestCase {
 public:
     void test_set_alpha() {
         auto stage = window->new_stage();
-        auto sprite = stage->sprites->new_sprite().fetch();
+        auto sprite = stage->sprites->new_sprite();
 
         sprite->set_alpha(0.5f);
 

--- a/tests/test_widgets.h
+++ b/tests/test_widgets.h
@@ -21,7 +21,7 @@ public:
     }
 
     void test_button_creation() {
-        auto button = stage_->ui->new_widget_as_button("Test", 100, 20).fetch();
+        auto button = stage_->ui->new_widget_as_button("Test", 100, 20);
 
         assert_equal(_u("Test"), button->text());
         assert_equal(100, button->requested_width());
@@ -29,8 +29,8 @@ public:
     }
 
     void test_focus_chain() {
-        auto widget1 = stage_->ui->new_widget_as_label("label1").fetch();
-        auto widget2 = stage_->ui->new_widget_as_label("label2").fetch();
+        auto widget1 = stage_->ui->new_widget_as_label("label1");
+        auto widget2 = stage_->ui->new_widget_as_label("label2");
 
         assert_is_null((ui::Widget*) widget1->focused_in_chain());
 

--- a/tests/test_widgets.h
+++ b/tests/test_widgets.h
@@ -12,7 +12,7 @@ class WidgetTest : public SimulantTestCase {
 public:
     void set_up() {
         SimulantTestCase::set_up();
-        stage_ = window->new_stage().fetch();
+        stage_ = window->new_stage();
     }
 
     void tear_down() {

--- a/tests/test_widgets.h
+++ b/tests/test_widgets.h
@@ -32,7 +32,7 @@ public:
         auto widget1 = stage_->ui->new_widget_as_label("label1").fetch();
         auto widget2 = stage_->ui->new_widget_as_label("label2").fetch();
 
-        assert_is_null(widget1->focused_in_chain());
+        assert_is_null((ui::Widget*) widget1->focused_in_chain());
 
         widget1->set_focus_next(widget2);
         widget1->focus();
@@ -44,7 +44,7 @@ public:
 
         widget2->blur();
 
-        assert_is_null(widget1->focused_in_chain());
+        assert_is_null((ui::Widget*) widget1->focused_in_chain());
     }
 
 private:


### PR DESCRIPTION
Fixes #94 

# Summary of Changes Introduced

 - All manual managers now return suitable pointer types (e.g. `new_actor()` returns `ActorPtr`)

This makes the API far nicer, but it does open up an issue with object deletion. Previously holding onto an ID would protect you from dangling pointers when objects are deleted (`.fetch()` would return nullptr) but now it's a little less safe. 

In future potentially it will be worth storing IDs separately from objects so that `id(some_ptr)` can become a thing, so `window->delete_stage(id(stage_ptr));` won't blow up if the stage was destroyed. 

# PR Checklist

- [x] I have documented any changes to the code in the documentation folder
- [x] I agree that the changes introduced in this PR are licensed under the [LGPL-3.0](https://opensource.org/licenses/LGPL-3.0)
- [x] I have added applicable tests, and not introduced any failures
