### PR TITLE
Remove `organism` requirement from Behaviour constructors

### DIFF
--- a/simulant/behaviours/fly.h
+++ b/simulant/behaviours/fly.h
@@ -32,17 +32,11 @@ class Fly:
     public Managed<Fly> {
 
 public:
-    Fly(Organism* container, const Property<smlt::SceneBase, smlt::Window>& window):
-        Fly(container, window.get()) {}
+    Fly(const Property<smlt::SceneBase, smlt::Window>& window):
+        Fly(window.get()) {}
 
-    Fly(Organism* container, Window* window):
+    Fly(Window* window):
         BehaviourWithInput(window->input.get()) {
-
-        object_ = dynamic_cast<Transformable*>(container);
-
-        if(!object_) {
-            throw std::logic_error("Tried to attach FlyBehaviour to something which wasn't an object");
-        }
     }
 
     const std::string name() const override { return "Fly by Keyboard"; }

--- a/simulant/behaviours/movement/airplane.cpp
+++ b/simulant/behaviours/movement/airplane.cpp
@@ -6,14 +6,13 @@
 namespace smlt {
 namespace behaviours {
 
-Airplane::Airplane(Organism *owner, Window *window):
+Airplane::Airplane(Window *window):
     BehaviourWithInput(window->input.get()),
-    owner_(owner),
     window_(window) {
 }
 
 void Airplane::fixed_update(float step) {
-    RigidBody* rigidbody = owner_->behaviour<RigidBody>();
+    RigidBody* rigidbody = organism->behaviour<RigidBody>();
     if(!rigidbody) {
         return;
     }

--- a/simulant/behaviours/movement/airplane.h
+++ b/simulant/behaviours/movement/airplane.h
@@ -11,7 +11,7 @@ class Airplane:
     public Managed<Airplane> {
 
 public:
-    Airplane(Organism* owner, Window* window);
+    Airplane(Window* window);
 
     void set_turn_speed(float x) { turn_speed_ = x; }
 
@@ -22,7 +22,6 @@ public:
 private:
     void on_behaviour_added(Organism *controllable);
 
-    Organism* owner_;
     Window* window_;
 
     float turn_speed_ = 10.0f;

--- a/simulant/behaviours/movement/hover_ship.cpp
+++ b/simulant/behaviours/movement/hover_ship.cpp
@@ -8,9 +8,8 @@
 namespace smlt {
 namespace behaviours {
 
-HoverShip::HoverShip(Organism* owner, Window* window):
-    BehaviourWithInput(window->input.get()),
-    owner_(owner) {
+HoverShip::HoverShip(Window* window):
+    BehaviourWithInput(window->input.get()) {
 
 }
 

--- a/simulant/behaviours/movement/hover_ship.h
+++ b/simulant/behaviours/movement/hover_ship.h
@@ -16,7 +16,7 @@ class HoverShip:
     public Managed<HoverShip> {
 
 public:
-    HoverShip(Organism* owner, Window* window);
+    HoverShip(Window* window);
 
     const std::string name() const {
         return "Hover Ship";
@@ -33,7 +33,6 @@ public:
 private:
     void on_behaviour_first_update(Organism* owner);
 
-    Organism* owner_ = nullptr;
     RigidBody* body_ = nullptr;
     RigidBodySimulation* simulation_ = nullptr;
 
@@ -44,6 +43,13 @@ private:
 
     float power_input_ = 0.0f;
     float turn_input_ = 0.0f;
+
+protected:
+    float power_input() const { return power_input_; }
+    void set_power_input(float pi) { power_input_ = pi; }
+
+    float turn_input() const { return turn_input_; }
+    void set_turn_input(float ti) { turn_input_ = ti; }
 };
 
 }

--- a/simulant/behaviours/movement/smooth_follow.cpp
+++ b/simulant/behaviours/movement/smooth_follow.cpp
@@ -7,8 +7,8 @@
 namespace smlt {
 namespace behaviours {
 
-SmoothFollow::SmoothFollow(Organism* controllable):
-    StageNodeBehaviour(controllable) {
+SmoothFollow::SmoothFollow():
+    StageNodeBehaviour() {
 
 }
 
@@ -27,17 +27,17 @@ void SmoothFollow::late_update(float dt) {
 
     // Keep within 0.0 - 1.0f;
     auto damping_to_apply = std::max(std::min(damping_ * dt, 1.0f), 0.0f);
-    owner->move_to_absolute(
-        owner->absolute_position().lerp(wanted_position, damping_to_apply)
+    stage_node->move_to_absolute(
+        stage_node->absolute_position().lerp(wanted_position, damping_to_apply)
     );
 
-    auto wanted_rotation = Quaternion::as_look_at((target_position - owner->absolute_position()).normalized(), target->absolute_rotation().up());
+    auto wanted_rotation = Quaternion::as_look_at((target_position - stage_node->absolute_position()).normalized(), target->absolute_rotation().up());
     wanted_rotation.inverse(); // << FIXME: This seems like a bug in as_look_at...
 
     // Keep within 0.0 - 1.0f;
     auto rot_damping_to_apply = std::max(std::min(rotation_damping_ * dt, 1.0f), 0.0f);
-    owner->rotate_to_absolute(
-        owner->absolute_rotation().slerp(wanted_rotation, rot_damping_to_apply)
+    stage_node->rotate_to_absolute(
+        stage_node->absolute_rotation().slerp(wanted_rotation, rot_damping_to_apply)
     );
 }
 

--- a/simulant/behaviours/movement/smooth_follow.h
+++ b/simulant/behaviours/movement/smooth_follow.h
@@ -15,7 +15,7 @@ class SmoothFollow:
     public Managed<SmoothFollow> {
 
 public:
-    SmoothFollow(Organism* controllable);
+    SmoothFollow();
 
     const std::string name() const {
         return "Smooth Follow";

--- a/simulant/behaviours/physics/body.h
+++ b/simulant/behaviours/physics/body.h
@@ -7,6 +7,7 @@
 #include "collider.h"
 
 #include "../behaviour.h"
+#include "../stage_node_behaviour.h"
 #include "../../generic/property.h"
 #include "../../types.h"
 
@@ -62,10 +63,10 @@ namespace impl {
 class ContactListener;
 
 class Body:
-    public Behaviour {
+    public StageNodeBehaviour {
 
 public:
-    Body(Organism* object, RigidBodySimulation* simulation);
+    Body(RigidBodySimulation* simulation);
     virtual ~Body();
 
     void move_to(const Vec3& position);
@@ -94,8 +95,6 @@ public:
     void register_collision_listener(CollisionListener* listener);
     void unregister_collision_listener(CollisionListener* listener);
 
-    Property<Body, StageNode> stage_node = { this, &Body::object_ };
-
     RigidBodySimulation* _simulation_ptr() const {
         if(auto ret = simulation_.lock()) {
             return ret.get();
@@ -106,7 +105,7 @@ public:
 
 protected:
     friend class smlt::behaviours::RigidBodySimulation;
-    StageNode* object_;
+
     b3Body* body_ = nullptr;
     std::weak_ptr<RigidBodySimulation> simulation_;
 
@@ -134,6 +133,8 @@ private:
 
     void contact_started(const Collision& collision);
     void contact_finished(const Collision &collision);
+
+    void on_behaviour_added(Organism* organism) override;
 };
 
 } // End impl

--- a/simulant/behaviours/physics/raycast_vehicle.cpp
+++ b/simulant/behaviours/physics/raycast_vehicle.cpp
@@ -26,12 +26,12 @@ namespace behaviours {
 
 static const float FLOAT_EPSILON = std::numeric_limits<float>::epsilon();
 
-RaycastVehicle::RaycastVehicle(smlt::Organism* object, RigidBodySimulation* simulation, float wheel_height):
-    RigidBody(object, simulation),
+RaycastVehicle::RaycastVehicle(RigidBodySimulation* simulation, float wheel_height):
+    RigidBody(simulation),
     wheel_height_(wheel_height) {
 
 
-    BoundableEntity* entity = dynamic_cast<BoundableEntity*>(object_);
+    BoundableEntity* entity = dynamic_cast<BoundableEntity*>(stage_node.get());
     AABB aabb = entity->aabb();
 
     float offset = 0.001;

--- a/simulant/behaviours/physics/raycast_vehicle.h
+++ b/simulant/behaviours/physics/raycast_vehicle.h
@@ -38,8 +38,7 @@ class RaycastVehicle:
     DEFINE_SIGNAL(VehicleAirbourneSignal, signal_vehicle_airbourne);
 
 public:    
-    RaycastVehicle(Organism *object,
-        RigidBodySimulation *simulation,
+    RaycastVehicle(RigidBodySimulation *simulation,
         float wheel_height
     );
 

--- a/simulant/behaviours/physics/rigid_body.cpp
+++ b/simulant/behaviours/physics/rigid_body.cpp
@@ -32,8 +32,8 @@ namespace smlt {
 namespace behaviours {
 
 
-RigidBody::RigidBody(Organism* object, RigidBodySimulation* simulation):
-    Body(object, simulation) {
+RigidBody::RigidBody(RigidBodySimulation* simulation):
+    Body(simulation) {
 
 }
 

--- a/simulant/behaviours/physics/rigid_body.h
+++ b/simulant/behaviours/physics/rigid_body.h
@@ -50,7 +50,7 @@ class RigidBody:
     public Managed<RigidBody> {
 
 public:
-    RigidBody(Organism* object, RigidBodySimulation *simulation);
+    RigidBody(RigidBodySimulation *simulation);
     ~RigidBody();
 
     void add_force(const Vec3& force);

--- a/simulant/behaviours/physics/simulation.cpp
+++ b/simulant/behaviours/physics/simulation.cpp
@@ -220,9 +220,10 @@ b3Body *RigidBodySimulation::acquire_body(impl::Body *body) {
 
     // If the body is attached to a stage node then set up the initial rotation
     // and position from that.
-    if(body->object_) {
-        to_b3vec3(body->object_->absolute_position(), def.position);
-        to_b3quat(body->object_->absolute_rotation(), def.orientation);
+
+    if(body->stage_node) {
+        to_b3vec3(body->stage_node->absolute_position(), def.position);
+        to_b3quat(body->stage_node->absolute_rotation(), def.orientation);
     }
 
     bodies_[body] = scene_->CreateBody(def);

--- a/simulant/behaviours/physics/static_body.cpp
+++ b/simulant/behaviours/physics/static_body.cpp
@@ -9,8 +9,8 @@ namespace behaviours {
 
 std::unordered_map<MeshID, std::shared_ptr<StaticBody::b3MeshGenerator>> StaticBody::mesh_cache;
 
-StaticBody::StaticBody(Organism* object, RigidBodySimulation* simulation):
-    Body(object, simulation) {
+StaticBody::StaticBody(RigidBodySimulation* simulation):
+    Body(simulation) {
 
 }
 

--- a/simulant/behaviours/physics/static_body.h
+++ b/simulant/behaviours/physics/static_body.h
@@ -13,7 +13,7 @@ class StaticBody:
     public Managed<StaticBody> {
 
 public:
-    StaticBody(Organism* object, RigidBodySimulation *simulation);
+    StaticBody(RigidBodySimulation *simulation);
     ~StaticBody();
 
     using impl::Body::init;

--- a/simulant/behaviours/stage_node_behaviour.h
+++ b/simulant/behaviours/stage_node_behaviour.h
@@ -11,19 +11,20 @@ class StageNodeBehaviour:
     public Behaviour {
 
 public:
-    StageNodeBehaviour(Organism* controllable):
-        owner_(dynamic_cast<StageNode*>(controllable)) {
-
-        if(!owner_) {
-            throw std::logic_error("Attempted to use StageNodeBehaviour on an object which wasn't a StageNode");
-        }
-    }
+    StageNodeBehaviour() = default;
+    Property<StageNodeBehaviour, StageNode> stage_node = { this, &StageNodeBehaviour::stage_node_ };
 
 protected:
-    Property<StageNodeBehaviour, StageNode> owner = { this, &StageNodeBehaviour::owner_ };
+    void on_behaviour_added(Organism* controllable) override {
+        stage_node_ = dynamic_cast<StageNode*>(controllable);
+    }
+
+    void on_behaviour_removed(Organism *controllable) override {
+        stage_node_ = nullptr;
+    }
 
 private:
-    StageNode* owner_;
+    StageNode* stage_node_ = nullptr;
 };
 
 }

--- a/tests/test_controllers.h
+++ b/tests/test_controllers.h
@@ -9,7 +9,7 @@ using namespace smlt;
 
 class TestBehaviour : public Behaviour, public Managed<TestBehaviour> {
 public:
-    TestBehaviour(Organism* c) {}
+    TestBehaviour() {}
 
     void on_behaviour_first_update(Organism* controllable) {
         call_count++;


### PR DESCRIPTION
This was problematic (requiring constantly calling up to the Behaviour constructor). Now `set_organism`
is called when a Behaviour is added to an Organism. The Body (RigidBody, StaticBody etc.) Behaviour now doesn't
create a body in the simulation until the on_behaviour_added call (which is triggered by set_organism).

# Summary of Changes Introduced

- Remove `organism` from the `Behaviour` constructor
- Added `Behaviour::organism` property
- Add `on_behaviour_added` and `on_behaviour_removed` hooks to the `Behaviour` class
- Made the physics behaviours inherit `StageNodeBehaviour` so that `stage_node` is an available property

# PR Checklist

- [ ] I have documented any changes to the code in the documentation folder
- [x] I agree that the changes introduced in this PR are licensed under the [LGPL-3.0](https://opensource.org/licenses/LGPL-3.0) 
- [x] I have added applicable tests, and not introduced any failures
