### PR TITLE
Lock cursor by default

### DIFF
--- a/simulant/input/input_manager.cpp
+++ b/simulant/input/input_manager.cpp
@@ -44,6 +44,14 @@ InputManager::InputManager(InputState *controller):
     auto fire2_js = new_axis("Fire2");
     fire2_js->set_type(AXIS_TYPE_JOYSTICK_BUTTON);
     fire2_js->set_positive_joystick_button(JoystickButtonID(1));
+
+    auto mouse_x = new_axis("MouseX");
+    mouse_x->set_type(AXIS_TYPE_MOUSE_AXIS);
+    mouse_x->set_mouse_axis(MOUSE_AXIS_0);
+
+    auto mouse_y = new_axis("MouseY");
+    mouse_y->set_type(AXIS_TYPE_MOUSE_AXIS);
+    mouse_y->set_mouse_axis(MOUSE_AXIS_1);
 }
 
 InputAxis* InputManager::new_axis(const std::string& name) {

--- a/simulant/kos_window.h
+++ b/simulant/kos_window.h
@@ -19,6 +19,7 @@ public:
     void set_title(const std::string&) override {} // No-op
     void cursor_position(int32_t &mouse_x, int32_t &mouse_y) override {} // No-op
     void show_cursor(bool) override {} // No-op
+    void lock_cursor(bool) override {} // No-op
 
     void swap_buffers() override;
     bool create_window(int width, int height, int bpp, bool fullscreen) override;

--- a/simulant/sdl2_window.cpp
+++ b/simulant/sdl2_window.cpp
@@ -51,6 +51,10 @@ void SDL2Window::show_cursor(bool value) {
 	SDL_ShowCursor(value);
 }
 
+void SDL2Window::lock_cursor(bool cursor_locked) {
+    SDL_SetRelativeMouseMode((cursor_locked) ? SDL_TRUE : SDL_FALSE);
+}
+
 void SDL2Window::cursor_position(int32_t& mouse_x, int32_t& mouse_y) {
 	SDL_GetMouseState(&mouse_x, &mouse_y);
 }

--- a/simulant/sdl2_window.h
+++ b/simulant/sdl2_window.h
@@ -45,6 +45,7 @@ public:
 
     void set_title(const std::string& title);
     void show_cursor(bool value=true);
+    void lock_cursor(bool cursor_locked=true);
     void cursor_position(int32_t& mouse_x, int32_t& mouse_y);
     
 private:

--- a/simulant/window.cpp
+++ b/simulant/window.cpp
@@ -237,6 +237,12 @@ bool Window::_init() {
         initialized_ = true;
     }
 
+    // By default, don't show the cursor
+    show_cursor(false);
+
+    // Lock the cursor by default
+    lock_cursor(true);
+
     L_DEBUG("Initialization finished");
 #ifdef _arch_dreamcast
         print_available_ram();

--- a/simulant/window.h
+++ b/simulant/window.h
@@ -152,6 +152,7 @@ public:
     virtual void set_title(const std::string& title) = 0;
     virtual void cursor_position(int32_t& mouse_x, int32_t& mouse_y) = 0;
     virtual void show_cursor(bool cursor_shown=true) = 0;
+    virtual void lock_cursor(bool cursor_locked=true) = 0;
     
     virtual void check_events() = 0;
     virtual void swap_buffers() = 0;


### PR DESCRIPTION
# Summary of Changes Introduced

 - Provide Window::lock_cursor
 - Call Window::lock_cursor() and Window::show_cursor(false) by default

# PR Checklist

- [ ] I have documented any changes to the code in the documentation folder
- [x] I agree that the changes introduced in this PR are licensed under the [LGPL-3.0](https://opensource.org/licenses/LGPL-3.0)
- [x] I have added applicable tests, and not introduced any failures
