### PR TITLE
Add frame limiter

### DIFF
--- a/documentation/refcount_managers.md
+++ b/documentation/refcount_managers.md
@@ -21,19 +21,19 @@ will be destroyed and a warning will be logged.
 
 For example, say you load a mesh, like so:
 
-    MeshID my_mesh = stage()->new_mesh_from_file("test.obj");
+    MeshID my_mesh = stage->new_mesh_from_file("test.obj");
     
 Once the new_mesh_from_file call returns, you have 10 seconds to do this:
 
-    auto mesh = stage()->mesh(my_mesh); //Marks resource as accessed
+    auto mesh = my_mesh.fetch(); //Marks resource as accessed
     // when 'mesh' goes out of scope, the mesh will be destroyed!
     
 or this:
 
-    stage()->new_actor_with_mesh(my_mesh); //Links the mesh to an actor, preventing its destruction    
+    stage->new_actor_with_mesh(my_mesh); //Links the mesh to an actor, preventing its destruction    
     
 Failure to access a resource within the 10 second grace period will result in its destruction,
-and any further attempts to access it will result in an ObjectDoesNotExist<T> exception.
+and any further attempts to access it will result in a NULL return value.
 
 # Disabling collection
 

--- a/documentation/todo.md
+++ b/documentation/todo.md
@@ -16,7 +16,7 @@ easy to use game engine. Until then, here are some of the things that need doing
  - Unit tests... lots of unit tests
  - Special effects (fog, projective textures etc.)
  - Animated, dynamic sky spheres/weather systems
- - Culling improvments, testing of the dynamic octree partitioner
+ - Culling improvements
  - Funky anti-aliasing
  - Steam controller compatibility 
  - General game controller improvements using SDL 2 features

--- a/documentation/window.md
+++ b/documentation/window.md
@@ -12,18 +12,9 @@ The following signals are available for the Window class:
  - signal<void (double)> signal_step();
  - signal<void ()> signal_shutdown();
 
-# The Message Bar
+## Platform Information
 
-Sometimes, when writing a game it is necessary to display a short message to the player, this could be something like "Your team mate is under attack", or "Base captured!" etc.
+The Window class has a `platform` property which is for platform-specific functionality and information. It has the following attributes:
 
-The global MessageBar instance is accessible from the Window instance using the Window::message_bar() method. The MessageBar provides the following messaging functions:
-    
- - alert(unicode);
- - warn(unicode);
- - inform(unicode);
- - notify_left(unicode);
- - notify_right(unicode);
-
-alert, warn and inform, display messages at the top-center of the screen with red, yellow and blue background respectively. The notify_left and notify_right methods display messages at the top-left and top-right respectively, without any background colouring.
-
-Calling any of the messaging functions will queue the message for display. One message will be displayed per second, and the bar will disappear once the queue is empty. It will of course beredisplayed if you queue more messages.
+ - `Platform::name()` - Returns the name of the platform. One of "linux", "windows", "darwin", "android" or "dreamcast"
+ - `Platform::sleep_for_us(int32_t)` - Sleeps for the specified number of microseconds. This is mainly because the Dreamcast compiler doesn't support `std::this_thread::sleep_for(...)`.

--- a/simulant.files
+++ b/simulant.files
@@ -576,6 +576,7 @@ simulant/partitioners/spatial_hash.cpp
 simulant/partitioners/spatial_hash.h
 simulant/pipeline_helper.cpp
 simulant/pipeline_helper.h
+simulant/platform.h
 simulant/procedural/constants.h
 simulant/procedural/mesh.h
 simulant/procedural/mesh/capsule.cpp

--- a/simulant/application.cpp
+++ b/simulant/application.cpp
@@ -45,7 +45,12 @@ void Application::construct_window(const AppConfig& config) {
     kazlog::get_logger("/")->add_handler(kazlog::Handler::ptr(new kazlog::StdIOHandler));
     L_DEBUG("Constructing the window");
 
-    window_ = SysWindow::create(this, config.width, config.height, config.bpp, config.fullscreen);
+    window_ = SysWindow::create(this, config.width, config.height, config.bpp, config.fullscreen, config.enable_vsync);
+
+    if(config_.target_frame_rate) {
+        float frame_time = (1.0f / float(config_.target_frame_rate)) * 1000.0f;
+        window_->request_frame_time(frame_time);
+    }
 
     for(auto& search_path: config.search_paths) {
         window_->resource_locator->add_search_path(search_path);

--- a/simulant/application.cpp
+++ b/simulant/application.cpp
@@ -32,23 +32,40 @@ namespace smlt { typedef SDL2Window SysWindow; }
 #include "scenes/loading.h"
 #include "input/input_state.h"
 
+#define SIMULANT_PROFILE_KEY "SIMULANT_PROFILE"
+
 namespace smlt {
 
 Application::Application(const AppConfig &config):
     config_(config) {
 
+    kazlog::get_logger("/")->add_handler(kazlog::Handler::ptr(new kazlog::StdIOHandler));
     construct_window(config);
 }
 
 void Application::construct_window(const AppConfig& config) {
+    /* Copy to remove const */
+    AppConfig config_copy = config;
 
-    kazlog::get_logger("/")->add_handler(kazlog::Handler::ptr(new kazlog::StdIOHandler));
+    /* If we're profiling, disable the frame time and vsync */
+    if(std::getenv(SIMULANT_PROFILE_KEY)) {
+        config_copy.target_frame_rate = std::numeric_limits<uint16_t>::max();
+        config_copy.enable_vsync = false;
+    }
+
     L_DEBUG("Constructing the window");
 
-    window_ = SysWindow::create(this, config.width, config.height, config.bpp, config.fullscreen, config.enable_vsync);
+    window_ = SysWindow::create(
+        this,
+        config_copy.width,
+        config_copy.height,
+        config_copy.bpp,
+        config_copy.fullscreen,
+        config_copy.enable_vsync
+    );
 
-    if(config_.target_frame_rate) {
-        float frame_time = (1.0f / float(config_.target_frame_rate)) * 1000.0f;
+    if(config_copy.target_frame_rate) {
+        float frame_time = (1.0f / float(config_copy.target_frame_rate)) * 1000.0f;
         window_->request_frame_time(frame_time);
     }
 

--- a/simulant/application.h
+++ b/simulant/application.h
@@ -52,6 +52,12 @@ struct AppConfig {
     uint32_t bpp = 0;
     bool fullscreen = true;
 
+    /* This is the frame limit; set to 0 to disable */
+    uint16_t target_frame_rate = 60;
+
+    /* Whether to enable vsync or not */
+    bool enable_vsync = false;
+
     // Additional paths for asset loading
     std::vector<unicode> search_paths;
 

--- a/simulant/kos_window.cpp
+++ b/simulant/kos_window.cpp
@@ -17,13 +17,9 @@ KOS_INIT_FLAGS(INIT_DEFAULT | INIT_MALLOCSTATS);
 #define SCREEN_HEIGHT 480
 #define SCREEN_DEPTH 32
 
-KOSWindow::KOSWindow(uint32_t width, uint32_t height, uint32_t bpp, bool fullscreen):
-    Window() {
+KOSWindow::KOSWindow(uint32_t width, uint32_t height, uint32_t bpp, bool fullscreen, bool vsync_enabled):
+    Window(width ? width : SCREEN_WIDTH, height ? height : SCREEN_HEIGHT, bpp ? bpp : SCREEN_DEPTH, true, true) {
 
-    set_width(SCREEN_WIDTH);
-    set_height(SCREEN_HEIGHT);
-    set_bpp(SCREEN_DEPTH);
-    set_fullscreen(true);
 }
 
 
@@ -31,10 +27,7 @@ void KOSWindow::swap_buffers() {
     glutSwapBuffers();
 }
 
-bool KOSWindow::create_window(int width, int height, int bpp, bool fullscreen) {
-    set_width(SCREEN_WIDTH);
-    set_height(SCREEN_HEIGHT);
-
+bool KOSWindow::create_window() {
     L_DEBUG("Initializing OpenGL");
 #ifdef _arch_dreamcast
         print_available_ram();

--- a/simulant/kos_window.cpp
+++ b/simulant/kos_window.cpp
@@ -20,6 +20,7 @@ KOS_INIT_FLAGS(INIT_DEFAULT | INIT_MALLOCSTATS);
 KOSWindow::KOSWindow(uint32_t width, uint32_t height, uint32_t bpp, bool fullscreen, bool vsync_enabled):
     Window(width ? width : SCREEN_WIDTH, height ? height : SCREEN_HEIGHT, bpp ? bpp : SCREEN_DEPTH, true, true) {
 
+    platform_.reset(new DreamcastPlatform);
 }
 
 

--- a/simulant/kos_window.h
+++ b/simulant/kos_window.h
@@ -18,11 +18,7 @@ class KOSWindow : public Window {
         }
     };
 
-    DreamcastPlatform platform_;
-
 public:
-    const Platform* platform() const override { return &platform_; }
-
     static Window::ptr create(Application* app, int width, int height, int bpp, bool fullscreen, bool enable_vsync) {
         return Window::create<KOSWindow>(app, width, height, bpp, fullscreen, enable_vsync);
     }

--- a/simulant/kos_window.h
+++ b/simulant/kos_window.h
@@ -5,16 +5,29 @@
 #include <kos.h>
 
 #include "window.h"
+#include "platform.h"
 
 namespace smlt {
 
 class KOSWindow : public Window {
+    class DreamcastPlatform : public Platform {
+    public:
+        std::string name() const override { return "dreamcast"; }
+        void sleep_ms(uint32_t ms) const {
+            usleep(ms * 1000);
+        }
+    };
+
+    DreamcastPlatform platform_;
+
 public:
-    static Window::ptr create(Application* app, int width=640, int height=480, int bpp=0, bool fullscreen=false) {
-        return Window::create<KOSWindow>(app, width, height, bpp, fullscreen);
+    const Platform* platform() const override { return &platform_; }
+
+    static Window::ptr create(Application* app, int width, int height, int bpp, bool fullscreen, bool enable_vsync) {
+        return Window::create<KOSWindow>(app, width, height, bpp, fullscreen, enable_vsync);
     }
 
-    KOSWindow(uint32_t width, uint32_t height, uint32_t bpp, bool fullscreen);
+    KOSWindow(uint32_t width, uint32_t height, uint32_t bpp, bool fullscreen, bool vsync_enabled);
 
     void set_title(const std::string&) override {} // No-op
     void cursor_position(int32_t &mouse_x, int32_t &mouse_y) override {} // No-op
@@ -22,7 +35,7 @@ public:
     void lock_cursor(bool) override {} // No-op
 
     void swap_buffers() override;
-    bool create_window(int width, int height, int bpp, bool fullscreen) override;
+    bool create_window() override;
     void destroy_window() override;
     void check_events() override;
 

--- a/simulant/platform.h
+++ b/simulant/platform.h
@@ -1,0 +1,20 @@
+#ifndef PLATFORM_H
+#define PLATFORM_H
+
+#include <cstdint>
+
+namespace smlt {
+
+class Platform {
+public:
+    // Information
+    virtual std::string name() const = 0;
+
+    // Platform-specific utils
+    virtual void sleep_ms(uint32_t ms) const = 0;
+};
+
+}
+
+
+#endif // PLATFORM_H

--- a/simulant/sdl2_window.cpp
+++ b/simulant/sdl2_window.cpp
@@ -29,6 +29,7 @@ namespace smlt {
 SDL2Window::SDL2Window(uint32_t width, uint32_t height, uint32_t bpp, bool fullscreen, bool enable_vsync):
     Window(width, height, bpp, fullscreen, enable_vsync) {
 
+    platform_.reset(new SDLPlatform);
 }
 
 SDL2Window::~SDL2Window() {

--- a/simulant/sdl2_window.cpp
+++ b/simulant/sdl2_window.cpp
@@ -410,4 +410,8 @@ void SDL2Window::swap_buffers() {
     SDL_GL_SwapWindow(screen_);
 }
 
+void SDL2Window::SDLPlatform::sleep_ms(uint32_t ms) const {
+    std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+}
+
 }

--- a/simulant/sdl2_window.cpp
+++ b/simulant/sdl2_window.cpp
@@ -26,11 +26,9 @@
 
 namespace smlt {
 
-SDL2Window::SDL2Window(uint32_t width, uint32_t height, uint32_t bpp, bool fullscreen) {
-    set_width(width);
-    set_height(height);
-    set_bpp(bpp);
-    set_fullscreen(fullscreen);
+SDL2Window::SDL2Window(uint32_t width, uint32_t height, uint32_t bpp, bool fullscreen, bool enable_vsync):
+    Window(width, height, bpp, fullscreen, enable_vsync) {
+
 }
 
 SDL2Window::~SDL2Window() {
@@ -255,14 +253,14 @@ void SDL2Window::denormalize(float x, float y, int& xout, int& yout) {
     yout = (int) (y * float(height()));
 }
 
-bool SDL2Window::create_window(int width, int height, int bpp, bool fullscreen) {
+bool SDL2Window::create_window() {
     if(SDL_Init(SDL_INIT_EVERYTHING) != 0) {
         L_ERROR(_F("Unable to initialize SDL {0}").format(SDL_GetError()));
         return false;
     }
 
     int32_t flags = SDL_WINDOW_OPENGL;
-    if(fullscreen) {
+    if(is_fullscreen()) {
         flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
     }
 
@@ -307,7 +305,7 @@ bool SDL2Window::create_window(int width, int height, int bpp, bool fullscreen) 
         "",
         SDL_WINDOWPOS_UNDEFINED,
         SDL_WINDOWPOS_UNDEFINED,
-        width, height,
+        width(), height(),
         flags
     );
 
@@ -328,14 +326,16 @@ bool SDL2Window::create_window(int width, int height, int bpp, bool fullscreen) 
     renderer_->init_context();
 
     //Reset the width and height to whatever was actually created
+    int32_t width = 0, height = 0;
     SDL_GetWindowSize(screen_, &width, &height);
 
     set_width(width);
     set_height(height);
 
+    SDL_GL_SetSwapInterval((vsync_enabled()) ? 1 : 0);
+
 #ifndef NDEBUG
     //DEBUG mode
-    SDL_GL_SetSwapInterval(0);
     SDL_ShowCursor(1);
 #else
     SDL_ShowCursor(0);

--- a/simulant/sdl2_window.h
+++ b/simulant/sdl2_window.h
@@ -43,9 +43,9 @@ class SDL2Window :
 #if defined(__LINUX__)
             return "linux";
 #elif defined(__APPLE__)
-            return "darwin"
+            return "darwin";
 #elif defined(__ANDROID__)
-            return "android"
+            return "android";
 #elif defined(WIN32)
             return "windows";
 #else
@@ -53,9 +53,7 @@ class SDL2Window :
 #endif
         }
 
-        void sleep_ms(uint32_t ms) const override {
-            std::this_thread::sleep_for(std::chrono::milliseconds(ms));
-        }
+        void sleep_ms(uint32_t ms) const override;
     };
 
     SDLPlatform platform_;

--- a/simulant/sdl2_window.h
+++ b/simulant/sdl2_window.h
@@ -56,12 +56,8 @@ class SDL2Window :
         void sleep_ms(uint32_t ms) const override;
     };
 
-    SDLPlatform platform_;
-public:
-    const Platform* platform() const {
-        return &platform_;
-    }
 
+public:
     static Window::ptr create(Application* app, int width, int height, int bpp, bool fullscreen, bool enable_vsync) {
         return Window::create<SDL2Window>(app, width, height, bpp, fullscreen, enable_vsync);
     }

--- a/simulant/sdl2_window.h
+++ b/simulant/sdl2_window.h
@@ -26,6 +26,7 @@
 #include "sdl2_keycodes.h"
 #include "generic/managed.h"
 #include "window.h"
+#include "platform.h"
 #include "sound_drivers/openal_sound_driver.h"
 
 namespace smlt {
@@ -35,12 +36,39 @@ int event_filter(void* user_data, SDL_Event* event);
 class SDL2Window :
     public Window {
 
+
+    class SDLPlatform : public Platform {
+    public:
+        std::string name() const override {
+#if defined(__LINUX__)
+            return "linux";
+#elif defined(__APPLE__)
+            return "darwin"
+#elif defined(__ANDROID__)
+            return "android"
+#elif defined(WIN32)
+            return "windows";
+#else
+    #error Currently unsupported platform
+#endif
+        }
+
+        void sleep_ms(uint32_t ms) const override {
+            std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+        }
+    };
+
+    SDLPlatform platform_;
 public:
-    static Window::ptr create(Application* app, int width=640, int height=480, int bpp=0, bool fullscreen=false) {
-        return Window::create<SDL2Window>(app, width, height, bpp, fullscreen);
+    const Platform* platform() const {
+        return &platform_;
     }
 
-    SDL2Window(uint32_t width, uint32_t height, uint32_t bpp, bool fullscreen);
+    static Window::ptr create(Application* app, int width, int height, int bpp, bool fullscreen, bool enable_vsync) {
+        return Window::create<SDL2Window>(app, width, height, bpp, fullscreen, enable_vsync);
+    }
+
+    SDL2Window(uint32_t width, uint32_t height, uint32_t bpp, bool fullscreen, bool enable_vsync);
     virtual ~SDL2Window();
 
     void set_title(const std::string& title);
@@ -52,8 +80,8 @@ private:
     SDL_Window* screen_;
     SDL_GLContext context_;
 
-    bool create_window(int width, int height, int bpp, bool fullscreen);
-    void destroy_window();
+    bool create_window() override;
+    void destroy_window() override;
 
     void check_events();
     void swap_buffers();

--- a/simulant/time_keeper.cpp
+++ b/simulant/time_keeper.cpp
@@ -12,6 +12,15 @@ TimeKeeper::TimeKeeper(const float fixed_step):
 
 }
 
+uint64_t TimeKeeper::now_in_us() const {
+#ifdef _arch_dreamcast
+    return timer_us_gettime64();
+#else
+    auto now = std::chrono::high_resolution_clock::now().time_since_epoch();
+    return std::chrono::duration_cast<std::chrono::microseconds>(now).count();
+#endif
+}
+
 bool TimeKeeper::init() {
 #ifdef _arch_dreamcast
     last_update_ = timer_us_gettime64();

--- a/simulant/time_keeper.h
+++ b/simulant/time_keeper.h
@@ -21,6 +21,8 @@ public:
 
     void update();
 
+    uint64_t now_in_us() const;
+
     float delta_time() const { return delta_time_; }
     float fixed_step() const { return fixed_step_; }
     float fixed_step_remainder() const;

--- a/simulant/window.cpp
+++ b/simulant/window.cpp
@@ -25,7 +25,7 @@
 
 #include "utils/gl_error.h"
 #include "window.h"
-
+#include "platform.h"
 #include "input/input_state.h"
 
 #include "loaders/texture_loader.h"
@@ -59,7 +59,7 @@
 
 namespace smlt {
 
-Window::Window():
+Window::Window(int width, int height, int bpp, bool fullscreen, bool enable_vsync):
     Source(this),
     StageManager(this),
     BackgroundManager(this),
@@ -74,6 +74,12 @@ Window::Window():
     frame_counter_frames_(0),
     frame_time_in_milliseconds_(0),
     time_keeper_(TimeKeeper::create(1.0 / Window::STEPS_PER_SECOND)) {
+
+    set_width(width);
+    set_height(height);
+    set_bpp(bpp);
+    set_fullscreen(fullscreen);
+    set_vsync_enabled(enable_vsync);
 
 }
 
@@ -193,7 +199,7 @@ bool Window::_init() {
     sound_driver_ = create_sound_driver();
     sound_driver_->startup();
 
-    bool result = create_window(width_, height_, bpp_, fullscreen_);
+    bool result = create_window();
 
     // Initialize the render_sequence once we have a renderer
     render_sequence_ = std::make_shared<RenderSequence>(this);
@@ -315,8 +321,25 @@ void Window::run_fixed_updates() {
     }
 }
 
+void Window::request_frame_time(float ms) {
+    requested_frame_time_ms_ = ms;
+}
+
+void Window::await_frame_time() {
+    auto this_time = time_keeper_->now_in_us();
+    while((float(this_time - last_frame_time_us_) * 0.001f) < requested_frame_time_ms_) {
+
+        platform()->sleep_ms(0);
+
+        this_time = time_keeper_->now_in_us();
+    }
+    last_frame_time_us_ = this_time;
+}
+
 bool Window::run_frame() {
     static bool first_frame = true;
+
+    await_frame_time(); /* Frame limiter */
 
     signal_frame_started_();
 

--- a/simulant/window.cpp
+++ b/simulant/window.cpp
@@ -329,7 +329,7 @@ void Window::await_frame_time() {
     auto this_time = time_keeper_->now_in_us();
     while((float(this_time - last_frame_time_us_) * 0.001f) < requested_frame_time_ms_) {
 
-        platform()->sleep_ms(0);
+        platform->sleep_ms(0);
 
         this_time = time_keeper_->now_in_us();
     }

--- a/simulant/window.h
+++ b/simulant/window.h
@@ -136,7 +136,6 @@ public:
     typedef std::shared_ptr<Window> ptr;
     static const int STEPS_PER_SECOND = 60;
 
-    virtual const Platform* platform() const = 0;
 
     template<typename T>
     static std::shared_ptr<Window> create(Application* app, int width, int height, int bpp, bool fullscreen, bool enable_vsync) {
@@ -284,7 +283,6 @@ protected:
 
     void set_escape_to_quit(bool value=true) { escape_to_quit_ = value; }
     bool escape_to_quit_enabled() const { return escape_to_quit_; }
-
 public:
     // Panels
     void register_panel(uint8_t function_key, std::shared_ptr<Panel> panel);
@@ -362,6 +360,7 @@ private:
 protected:
     InputState* _input_state() const { return input_state_.get(); }
 
+    std::shared_ptr<Platform> platform_;
 public:
     //Read only properties
     Property<Window, ResourceManager> shared_assets = { this, &Window::resource_manager_ };
@@ -377,6 +376,7 @@ public:
     Property<Window, InputManager> input = {this, &Window::input_manager_};
     Property<Window, InputState> input_state = {this, &Window::input_state_};
     Property<Window, Stats> stats = { this, &Window::stats_ };
+    Property<Window, Platform> platform = {this, &Window::platform_};
 
     SoundDriver* _sound_driver() const { return sound_driver_.get(); }
 

--- a/simulant/window.h
+++ b/simulant/window.h
@@ -382,6 +382,7 @@ public:
 
     void run_update();
     void run_fixed_updates();
+    void request_frame_time(float ms);
 };
 
 }

--- a/simulant/window.h
+++ b/simulant/window.h
@@ -382,7 +382,6 @@ public:
 
     void run_update();
     void run_fixed_updates();
-    void request_frame_time(float ms);
 };
 
 }

--- a/tests/global.h
+++ b/tests/global.h
@@ -17,9 +17,9 @@ public:
     void set_up() {
         if(!window) {
 #ifdef _arch_dreamcast
-            window = smlt::KOSWindow::create(nullptr);
+            window = smlt::KOSWindow::create(nullptr, 640, 480, 32, false, true);
 #else
-            window = smlt::SDL2Window::create(nullptr);
+            window = smlt::SDL2Window::create(nullptr, 640, 480, 0, false, true);
 #endif
             window->_init();
             window->set_logging_level(smlt::LOG_LEVEL_NONE);


### PR DESCRIPTION
Fixes #115 

- Adds `AppConfig::target_frame_rate` and `AppConfig::enable_vsync`
- Adds support for disabling frame limiting with SIMULANT_PROFILE=1
- Adds window->platform() for returning platform specific information (e.g. the platform name) 
- Adds `window->platform()->sleep_in_us` as platform-specific utility method

# PR Checklist

- [ ] I have documented any changes to the code in the documentation folder
- [x] I agree that the changes introduced in this PR are licensed under the [LGPL-3.0](https://opensource.org/licenses/LGPL-3.0) ([Why?](../documentation/license.md))
- [ ] I have added applicable tests, and not introduced any failures
