### PR TITLE
Simplify partitioning

### DIFF
--- a/simulant/behaviours/physics/simulation.h
+++ b/simulant/behaviours/physics/simulation.h
@@ -27,8 +27,7 @@ namespace impl {
 typedef sig::signal<void ()> SimulationPreStepSignal;
 
 class RigidBodySimulation:
-    public Managed<RigidBodySimulation>,
-    public std::enable_shared_from_this<RigidBodySimulation> {
+    public Managed<RigidBodySimulation> {
 
     DEFINE_SIGNAL(SimulationPreStepSignal, signal_simulation_pre_step);
 

--- a/simulant/generic/managed.h
+++ b/simulant/generic/managed.h
@@ -53,7 +53,7 @@ public:
 };
 
 template<typename T>
-class Managed : public virtual ManagedBase {
+class Managed : public virtual ManagedBase, public std::enable_shared_from_this<T> {
 public:
     typedef std::shared_ptr<T> ptr;
     typedef std::weak_ptr<T> wptr;

--- a/simulant/managers/skybox_manager.cpp
+++ b/simulant/managers/skybox_manager.cpp
@@ -30,7 +30,7 @@ namespace smlt {
 
 Skybox::Skybox(SkyID id, SkyManager* manager):
     generic::Identifiable<SkyID>(id),
-    StageNode(&(Stage&)manager->stage),
+    ContainerNode(&(Stage&)manager->stage),
     manager_(manager) {
 
 }

--- a/simulant/managers/skybox_manager.h
+++ b/simulant/managers/skybox_manager.h
@@ -44,7 +44,7 @@ class SkyManager;
 class Skybox :
     public Managed<Skybox>,
     public generic::Identifiable<SkyID>,
-    public StageNode {
+    public ContainerNode {
 
 public:
     constexpr static float DEFAULT_SIZE = 1024.0f;
@@ -71,6 +71,7 @@ public:
     const AABB& aabb() const override;
 
     void update(float step) override {}
+
 private:
     friend class SkyManager;
 

--- a/simulant/meshes/mesh.h
+++ b/simulant/meshes/mesh.h
@@ -61,8 +61,7 @@ class Mesh :
     public Loadable,
     public Managed<Mesh>,
     public generic::Identifiable<MeshID>,
-    public KeyFrameAnimated,
-    public std::enable_shared_from_this<Mesh> {
+    public KeyFrameAnimated {
 
     DEFINE_SIGNAL(SignalAnimationEnabled, signal_animation_enabled);
 

--- a/simulant/meshes/submesh.h
+++ b/simulant/meshes/submesh.h
@@ -31,8 +31,7 @@ private:
 
 class SubMesh :
     public SubMeshInterface,
-    public Managed<SubMesh>,
-    public std::enable_shared_from_this<SubMesh> {
+    public Managed<SubMesh> {
 
 public:
     SubMesh(

--- a/simulant/nodes/actor.cpp
+++ b/simulant/nodes/actor.cpp
@@ -335,6 +335,14 @@ void Actor::each(std::function<void (uint32_t, SubActor*)> callback) {
     }
 }
 
+RenderableList Actor::_get_renderables(const Frustum &frustum) const {
+    auto ret = RenderableList();
+    for(auto& actor: subactors_) {
+        ret.push_back(std::const_pointer_cast<SubActor>(actor));
+    }
+    return ret;
+}
+
 
 VertexData* SubActor::get_vertex_data() const {
     return submesh()->vertex_data.get();

--- a/simulant/nodes/actor.h
+++ b/simulant/nodes/actor.h
@@ -112,6 +112,9 @@ public:
         StageNode::cleanup();
     }
 
+    RenderableList _get_renderables(const Frustum &frustum) const {
+        return RenderableList(subactors_.begin(), subactors_.end());
+    }
 private:
     // Used for animated meshes
     std::unique_ptr<HardwareBuffer> interpolated_vertex_buffer_;
@@ -144,8 +147,7 @@ class SubActor :
     public SubMeshInterface,
     public virtual BoundableEntity,
     public Managed<SubActor>,
-    public Renderable,
-    public std::enable_shared_from_this<SubActor> {
+    public Renderable {
 
 public:
     const MaterialID material_id() const;

--- a/simulant/nodes/actor.h
+++ b/simulant/nodes/actor.h
@@ -112,9 +112,7 @@ public:
         StageNode::cleanup();
     }
 
-    RenderableList _get_renderables(const Frustum &frustum) const {
-        return RenderableList(subactors_.begin(), subactors_.end());
-    }
+    RenderableList _get_renderables(const Frustum &frustum) const;
 private:
     // Used for animated meshes
     std::unique_ptr<HardwareBuffer> interpolated_vertex_buffer_;

--- a/simulant/nodes/camera.cpp
+++ b/simulant/nodes/camera.cpp
@@ -7,7 +7,7 @@ namespace smlt {
 
 
 Camera::Camera(CameraID camera_id, Stage *stage):
-    StageNode(stage),
+    ContainerNode(stage),
     generic::Identifiable<CameraID>(camera_id) {
 
     assert(stage);

--- a/simulant/nodes/camera.h
+++ b/simulant/nodes/camera.h
@@ -11,11 +11,13 @@ namespace smlt {
 class RenderTarget;
 
 class Camera:
-    public StageNode,
+    public ContainerNode,
     public generic::Identifiable<CameraID>,
-    public Managed<Camera> {
+    public Managed<Camera>{
 
 public:
+    using ContainerNode::_get_renderables;
+
     Camera(CameraID camera_id, Stage* stage);
     ~Camera();
 

--- a/simulant/nodes/geom.cpp
+++ b/simulant/nodes/geom.cpp
@@ -52,5 +52,9 @@ void Geom::ask_owner_for_destruction() {
     stage->delete_geom(id());
 }
 
+std::vector<std::shared_ptr<Renderable>> Geom::_get_renderables(const Frustum &frustum) const {
+    return culler_->renderables_visible(frustum);
+}
+
 
 }

--- a/simulant/nodes/geom.h
+++ b/simulant/nodes/geom.h
@@ -46,8 +46,7 @@ class Geom :
     public virtual Boundable,
     public Managed<Geom>,
     public generic::Identifiable<GeomID>,
-    public Source,
-    public std::enable_shared_from_this<Geom> {
+    public Source {
 
 public:
     Geom(GeomID id, Stage* stage, SoundDriver *sound_driver, MeshID mesh, const Vec3& position=Vec3(), const Quaternion rotation=Quaternion());
@@ -66,6 +65,7 @@ public:
 
     bool init() override;
 
+    std::vector<std::shared_ptr<Renderable>> _get_renderables(const Frustum& frustum) const;
 private:
     MeshID mesh_id_;
     RenderPriority render_priority_ = RENDER_PRIORITY_MAIN;

--- a/simulant/nodes/light.cpp
+++ b/simulant/nodes/light.cpp
@@ -23,7 +23,7 @@
 namespace smlt {
 
 Light::Light(LightID lid, Stage* stage):
-    StageNode(stage),
+    ContainerNode(stage),
     generic::Identifiable<LightID>(lid),
     type_(LIGHT_TYPE_POINT) {
 

--- a/simulant/nodes/light.h
+++ b/simulant/nodes/light.h
@@ -28,7 +28,7 @@
 namespace smlt {
 
 class Light :
-    public StageNode,
+    public ContainerNode,
     public generic::Identifiable<LightID>,
     public Managed<Light> {
 

--- a/simulant/nodes/particle_system.h
+++ b/simulant/nodes/particle_system.h
@@ -30,8 +30,7 @@ class ParticleSystem :
     public Source,
     public Loadable,
     public HasMutableRenderPriority,
-    public Renderable,
-    public std::enable_shared_from_this<ParticleSystem> {
+    public Renderable {
 
     DEFINE_SIGNAL(ParticleSystemMaterialChangedSignal, signal_material_changed);
 
@@ -120,6 +119,13 @@ public:
         auto m = std::make_shared<M>(std::forward<Args>(args)...);
         manipulators_.push_back(m);
         return m.get();
+    }
+
+    RenderableList _get_renderables(const Frustum &frustum) const {
+        auto ret = RenderableList();
+        std::shared_ptr<Renderable> sptr = std::const_pointer_cast<ParticleSystem>(shared_from_this());
+        ret.push_back(sptr);
+        return ret;
     }
 
 private:

--- a/simulant/nodes/sprite.cpp
+++ b/simulant/nodes/sprite.cpp
@@ -29,7 +29,7 @@
 using namespace smlt;
 
 Sprite::Sprite(SpriteID id, SpriteManager *manager, SoundDriver* sound_driver):
-    StageNode(manager->stage.get()),
+    ContainerNode(manager->stage.get()),
     generic::Identifiable<SpriteID>(id),
     Source(manager->stage, sound_driver),
     manager_(manager) {

--- a/simulant/nodes/sprite.h
+++ b/simulant/nodes/sprite.h
@@ -41,14 +41,15 @@ struct SpritesheetAttrs {
 };
 
 class Sprite :
-    public StageNode,
+    public ContainerNode,
     public Managed<Sprite>,
     public generic::Identifiable<SpriteID>,
     public KeyFrameAnimated,
-    public Source,
-    public std::enable_shared_from_this<Sprite> {
+    public Source {
 
 public:
+    using ContainerNode::_get_renderables;
+
     //Ownable interface (inherited through ParentSetterMixin)
     void ask_owner_for_destruction() override;
 

--- a/simulant/nodes/stage_node.h
+++ b/simulant/nodes/stage_node.h
@@ -16,6 +16,8 @@ namespace smlt {
 
 typedef sig::signal<void (AABB)> BoundsUpdatedSignal;
 
+typedef std::vector<std::shared_ptr<Renderable>> RenderableList;
+
 class StageNode:
     public TreeNode,
     public Nameable,
@@ -90,6 +92,9 @@ public:
 
     StageNode* find_child_with_name(const std::string& name);
 
+    /* Return a list of renderables to pass into the render queue */
+    virtual RenderableList _get_renderables(const smlt::Frustum& frustum) const = 0;
+
 protected:
     // Faster than properties, useful for subclasses where a clean API isn't as important
     Stage* get_stage() const { return stage_; }
@@ -118,6 +123,20 @@ private:
     // By default, always cast and receive shadows
     ShadowCast shadow_cast_ = SHADOW_CAST_ALWAYS;
     ShadowReceive shadow_receive_ = SHADOW_RECEIVE_ALWAYS;
+};
+
+
+class ContainerNode : public StageNode {
+public:
+    ContainerNode(Stage* stage):
+        StageNode(stage) {}
+
+    /* Containers don't directly have renderables, but their children do */
+    std::vector<std::shared_ptr<Renderable>> _get_renderables(const Frustum& frustum) const {
+        return std::vector<std::shared_ptr<Renderable>>();
+    }
+
+    virtual ~ContainerNode() {}
 };
 
 }

--- a/simulant/nodes/ui/widget.cpp
+++ b/simulant/nodes/ui/widget.cpp
@@ -10,7 +10,7 @@ namespace smlt {
 namespace ui {
 
 Widget::Widget(WidgetID id, UIManager *owner, UIConfig *defaults):
-    StageNode(owner->stage()),
+    ContainerNode(owner->stage()),
     generic::Identifiable<WidgetID>(id),
     owner_(owner) {
 

--- a/simulant/nodes/ui/widget.h
+++ b/simulant/nodes/ui/widget.h
@@ -96,7 +96,7 @@ typedef sig::signal<void ()> WidgetFocusedSignal;
 typedef sig::signal<void ()> WidgetBlurredSignal;
 
 class Widget:
-    public StageNode,
+    public ContainerNode,
     public generic::Identifiable<WidgetID> {
 
     DEFINE_SIGNAL(WidgetPressedSignal, signal_pressed);

--- a/simulant/partitioner.h
+++ b/simulant/partitioner.h
@@ -87,7 +87,7 @@ public:
     virtual void lights_and_geometry_visible_from(
         CameraID camera_id,
         std::vector<LightID>& lights_out,
-        std::vector<std::shared_ptr<Renderable>>& geom_out
+        std::vector<StageNode*>& geom_out
     ) = 0;
 
     virtual MeshID debug_mesh_id() { return MeshID(); }

--- a/simulant/partitioners/null_partitioner.cpp
+++ b/simulant/partitioners/null_partitioner.cpp
@@ -28,7 +28,8 @@
 namespace smlt {
 
 void NullPartitioner::lights_and_geometry_visible_from(
-        CameraID camera_id, std::vector<LightID> &lights_out, std::vector<std::shared_ptr<Renderable> > &geom_out) {
+        CameraID camera_id, std::vector<LightID> &lights_out,
+        std::vector<StageNode*> &geom_out) {
 
     auto frustum = stage->camera(camera_id)->frustum();
 
@@ -42,12 +43,9 @@ void NullPartitioner::lights_and_geometry_visible_from(
 
     for(ActorID eid: all_actors_) {
         auto actor = stage->actor(eid);
-        auto subactors = actor->_subactors();
 
-        for(auto ent: subactors) {
-            if(frustum.intersects_aabb(ent->transformed_aabb())) {
-                geom_out.push_back(ent);
-            }
+        if(frustum.intersects_aabb(actor->transformed_aabb())) {
+            geom_out.push_back(actor);
         }
     }
 
@@ -55,10 +53,9 @@ void NullPartitioner::lights_and_geometry_visible_from(
         auto system = stage->particle_system(ps);
         auto aabb = system->transformed_aabb();
         if(frustum.intersects_aabb(aabb)) {
-            geom_out.push_back(system->shared_from_this());
+            geom_out.push_back(system);
         }
     }
-
 }
 
 void NullPartitioner::apply_staged_write(const StagedWrite &write) {

--- a/simulant/partitioners/null_partitioner.h
+++ b/simulant/partitioners/null_partitioner.h
@@ -30,7 +30,11 @@ public:
     NullPartitioner(Stage* ss):
         Partitioner(ss) {}
 
-    void lights_and_geometry_visible_from(CameraID camera_id, std::vector<LightID> &lights_out, std::vector<std::shared_ptr<Renderable> > &geom_out);
+    void lights_and_geometry_visible_from(
+        CameraID camera_id,
+        std::vector<LightID> &lights_out,
+        std::vector<StageNode*> &geom_out
+    );
 
 private:
     void apply_staged_write(const StagedWrite& write);

--- a/simulant/partitioners/spatial_hash.h
+++ b/simulant/partitioners/spatial_hash.h
@@ -48,7 +48,11 @@ public:
     SpatialHashPartitioner(Stage* ss);
     ~SpatialHashPartitioner();
 
-    void lights_and_geometry_visible_from(CameraID camera_id, std::vector<LightID> &lights_out, std::vector<std::shared_ptr<Renderable> > &geom_out);
+    void lights_and_geometry_visible_from(
+        CameraID camera_id,
+        std::vector<LightID> &lights_out,
+        std::vector<StageNode*> &geom_out
+    );
 
 private:
     void stage_add_actor(ActorID obj);

--- a/simulant/sound.h
+++ b/simulant/sound.h
@@ -43,8 +43,7 @@ class Sound :
     public Managed<Sound>,
     public generic::Identifiable<SoundID>,
     public Resource,
-    public Loadable,
-    public std::enable_shared_from_this<Sound> {
+    public Loadable {
 
 public:
     Sound(SoundID id, ResourceManager* resource_manager, SoundDriver* sound_driver);

--- a/simulant/stage.cpp
+++ b/simulant/stage.cpp
@@ -44,7 +44,7 @@ const Colour DEFAULT_LIGHT_COLOUR = Colour(1.0, 1.0, 251.0 / 255.0, 1.0);
 
 Stage::Stage(StageID id, Window *parent, AvailablePartitioner partitioner):
     WindowHolder(parent),
-    StageNode(this),
+    ContainerNode(this),
     generic::Identifiable<StageID>(id),
     CameraManager(this),
     ui_(new ui::UIManager(this)),

--- a/simulant/stage.h
+++ b/simulant/stage.h
@@ -91,7 +91,7 @@ typedef sig::signal<void (CameraID, Viewport)> StagePostRenderSignal;
 extern const Colour DEFAULT_LIGHT_COLOUR;
 
 class Stage:
-    public StageNode,
+    public ContainerNode,
     public Managed<Stage>,
     public generic::Identifiable<StageID>,
     public ActorManager,

--- a/simulant/texture.h
+++ b/simulant/texture.h
@@ -154,8 +154,7 @@ class Texture :
     public generic::Identifiable<TextureID>,
     public Managed<Texture>,
     public Updateable,
-    public RenderTarget,
-    public std::enable_shared_from_this<Texture> {
+    public RenderTarget {
 
 public:
     static const TextureChannelSet DEFAULT_SOURCE_CHANNELS;

--- a/tests/test_partitioner.h
+++ b/tests/test_partitioner.h
@@ -20,7 +20,7 @@ public:
         cb_(write);
     }
 
-    void lights_and_geometry_visible_from(CameraID camera_id, std::vector<LightID> &lights_out, std::vector<std::shared_ptr<Renderable> > &geom_out) {
+    void lights_and_geometry_visible_from(CameraID camera_id, std::vector<LightID> &lights_out, std::vector<StageNode*> &geom_out) {
 
     }
 


### PR DESCRIPTION
#119 

# Summary of Changes Introduced

 - `StageNodes` (rather than `Renderables`) are now returned from the partitioners
 - Light distance is calculated from the `StageNode` centre, rather than the `Renderable` centre
 - This results in a performance boost, and makes more logical sense (!)

# PR Checklist

- [ ] I have documented any user-visible changes to the code in the documentation folder
- [x] I agree that the changes introduced in this PR are licensed under the [LGPL-3.0](https://opensource.org/licenses/LGPL-3.0) license ([Why?](https://github.com/Kazade/simulant-engine/blob/master/documentation/license.md))
- [x] I have added applicable tests, or at least not introduced any failures
