### PR TITLE
Remove unneeded const from simple return types

### DIFF
--- a/simulant/interfaces/boundable.h
+++ b/simulant/interfaces/boundable.h
@@ -13,27 +13,27 @@ class Boundable {
 public:
     virtual const AABB& aabb() const = 0;
 
-    virtual const float width() const {
+    virtual float width() const {
         AABB box = aabb();
         return box.width();
     }
 
-    virtual const float height() const {
+    virtual float height() const {
         AABB box = aabb();
         return box.height();
     }
 
-    virtual const float depth() const {
+    virtual float depth() const {
         AABB box = aabb();
         return box.depth();
     }
 
-    virtual const float half_width() const { return width() * 0.5f; }
-    virtual const float half_height() const { return height() * 0.5f; }
-    virtual const float half_depth() const { return depth() * 0.5f; }
+    virtual float half_width() const { return width() * 0.5f; }
+    virtual float half_height() const { return height() * 0.5f; }
+    virtual float half_depth() const { return depth() * 0.5f; }
 
-    virtual const float diameter() const { return std::max(width(), std::max(height(), depth())); }
-    virtual const float radius() const { return diameter() * 0.5f; }
+    virtual float diameter() const { return std::max(width(), std::max(height(), depth())); }
+    virtual float radius() const { return diameter() * 0.5f; }
 };
 
 /**

--- a/simulant/interfaces/nameable.h
+++ b/simulant/interfaces/nameable.h
@@ -15,7 +15,7 @@ public:
 
     void set_name(const unicode& name) { name_ = name; }
     const unicode name() const { return name_; }
-    const bool has_name() const { return !name_.empty(); }
+    bool has_name() const { return !name_.empty(); }
 
     virtual unicode to_unicode() const { return name_; }
 

--- a/simulant/managers.cpp
+++ b/simulant/managers.cpp
@@ -90,7 +90,7 @@ uint32_t CameraManager::camera_count() const {
     return cameras_.count();
 }
 
-const bool CameraManager::has_camera(CameraID id) const {
+bool CameraManager::has_camera(CameraID id) const {
     return cameras_.contains(id);
 }
 

--- a/simulant/managers.h
+++ b/simulant/managers.h
@@ -42,7 +42,7 @@ public:
     CameraPtr camera(CameraID c);
     void delete_camera(CameraID cid);
     uint32_t camera_count() const;
-    const bool has_camera(CameraID id) const;
+    bool has_camera(CameraID id) const;
     void delete_all_cameras();
 
 private:

--- a/simulant/managers/skybox_manager.h
+++ b/simulant/managers/skybox_manager.h
@@ -55,7 +55,7 @@ public:
     void cleanup() override;
 
     void set_size(float size) { width_ = size; }
-    const float size() const { return width_; }
+    float size() const { return width_; }
 
     void generate(
         const unicode& up,

--- a/simulant/math/aabb.h
+++ b/simulant/math/aabb.h
@@ -114,15 +114,15 @@ public:
     AABB(const Vec3* vertices, const std::size_t count);    
     AABB(const VertexData& vertex_data);
 
-    const float width() const {
+    float width() const {
         return fabs(max_.x - min_.x);
     }
 
-    const float height() const {
+    float height() const {
         return fabs(max_.y - min_.y);
     }
 
-    const float depth() const  {
+    float depth() const  {
         return fabs(max_.z - min_.z);
     }
 
@@ -130,11 +130,11 @@ public:
         return Vec3(width(), height(), depth());
     }
 
-    const float max_dimension() const {
+    float max_dimension() const {
         return std::max(width(), std::max(height(), depth()));
     }
 
-    const float min_dimension() const {
+    float min_dimension() const {
         return std::min(width(), std::min(height(), depth()));
     }
 
@@ -145,7 +145,7 @@ public:
         return Vec3(min_) + ((Vec3(max_) - Vec3(min_)) * 0.5f);
     }
 
-    const bool has_zero_area() const {
+    bool has_zero_area() const {
         /*
          * Returns True if the AABB has two or more zero dimensions
          */

--- a/simulant/meshes/submesh.h
+++ b/simulant/meshes/submesh.h
@@ -19,7 +19,7 @@ public:
     virtual ~SubMeshInterface() {}
 
     virtual const MaterialID material_id() const = 0;
-    virtual const MeshArrangement arrangement() const = 0;
+    virtual MeshArrangement arrangement() const = 0;
 
     Property<SubMeshInterface, VertexData, true> vertex_data = { this, &SubMeshInterface::get_vertex_data };
     Property<SubMeshInterface, IndexData, true> index_data = { this, &SubMeshInterface::get_index_data };
@@ -47,7 +47,7 @@ public:
     const MaterialID material_id() const;
     void set_material_id(MaterialID mat);
 
-    const MeshArrangement arrangement() const { return arrangement_; }
+    MeshArrangement arrangement() const { return arrangement_; }
 
     const AABB& aabb() const {
         return bounds_;

--- a/simulant/nodes/actor.h
+++ b/simulant/nodes/actor.h
@@ -59,7 +59,7 @@ public:
     bool has_mesh() const { return bool(mesh_); }
     void set_mesh(MeshID mesh);
 
-    const uint16_t subactor_count() const {
+    uint16_t subactor_count() const {
         return subactors_.size();
     }
 
@@ -151,11 +151,11 @@ public:
     void override_material_id(MaterialID material);
     void remove_material_id_override();
 
-    const MeshArrangement arrangement() const { return submesh()->arrangement(); }
+    MeshArrangement arrangement() const { return submesh()->arrangement(); }
 
     RenderPriority render_priority() const { return parent_.render_priority(); }
     Mat4 final_transformation() const { return parent_.absolute_transformation(); }
-    const bool is_visible() const { return parent_.is_visible(); }
+    bool is_visible() const { return parent_.is_visible(); }
 
     /* BoundableAndTransformable interface implementation */
 

--- a/simulant/nodes/geoms/geom_culler_renderable.cpp
+++ b/simulant/nodes/geoms/geom_culler_renderable.cpp
@@ -61,7 +61,7 @@ RenderPriority GeomCullerRenderable::render_priority() const {
     return culler_->geom_->render_priority();
 }
 
-const bool GeomCullerRenderable::is_visible() const {
+bool GeomCullerRenderable::is_visible() const {
     return culler_->geom_->is_visible();
 }
 

--- a/simulant/nodes/geoms/geom_culler_renderable.h
+++ b/simulant/nodes/geoms/geom_culler_renderable.h
@@ -11,7 +11,7 @@ class GeomCullerRenderable : public Renderable {
 public:
     GeomCullerRenderable(GeomCuller* owner, MaterialID mat_id, IndexType index_type);
 
-    const MeshArrangement arrangement() const {
+    MeshArrangement arrangement() const {
         return MESH_ARRANGEMENT_TRIANGLES;
     }
 
@@ -25,7 +25,7 @@ public:
     RenderPriority render_priority() const;
     Mat4 final_transformation() const { return Mat4(); }
     const MaterialID material_id() const { return material_id_; }
-    const bool is_visible() const;
+    bool is_visible() const;
     IndexData& _indices() { return indices_; }
     const AABB transformed_aabb() const;
     const AABB& aabb() const;

--- a/simulant/nodes/particle_system.h
+++ b/simulant/nodes/particle_system.h
@@ -64,7 +64,7 @@ public:
 
     //Renderable stuff
 
-    const MeshArrangement arrangement() const override { return MESH_ARRANGEMENT_TRIANGLES; }
+    MeshArrangement arrangement() const override { return MESH_ARRANGEMENT_TRIANGLES; }
     virtual Mat4 final_transformation() const override {
         return Mat4(); //Particles are absolutely positioned in the world
     }
@@ -106,7 +106,7 @@ public:
         return HasMutableRenderPriority::render_priority();
     }
 
-    const bool is_visible() const override {
+    bool is_visible() const override {
         return StageNode::is_visible();
     }
 

--- a/simulant/panels/panel.h
+++ b/simulant/panels/panel.h
@@ -27,7 +27,7 @@ class Panel:
 public:
     virtual ~Panel() {}
 
-    const bool is_active() const { return is_active_; }
+    bool is_active() const { return is_active_; }
 
     void activate() {
         if(is_active_) return;

--- a/simulant/renderers/batching/renderable.h
+++ b/simulant/renderers/batching/renderable.h
@@ -63,7 +63,7 @@ class Renderable:
 public:
     virtual ~Renderable() {}
 
-    virtual const MeshArrangement arrangement() const = 0;
+    virtual MeshArrangement arrangement() const = 0;
 
     virtual void prepare_buffers(Renderer* renderer) = 0;
 
@@ -78,7 +78,7 @@ public:
     virtual Mat4 final_transformation() const = 0;
 
     virtual const MaterialID material_id() const = 0;
-    virtual const bool is_visible() const = 0;
+    virtual bool is_visible() const = 0;
 
     void update_last_visible_frame_id(uint64_t frame_id) {
         last_visible_frame_id_ = frame_id;

--- a/simulant/renderers/gl2x/gpu_program.cpp
+++ b/simulant/renderers/gl2x/gpu_program.cpp
@@ -185,7 +185,7 @@ void GPUProgram::set_attribute_location(const std::string& attribute, GLint loca
     needs_relink_ = true;
 }
 
-const bool GPUProgram::is_current() const {
+bool GPUProgram::is_current() const {
     GLint current = 0;
     GLCheck(glGetIntegerv, GL_CURRENT_PROGRAM, &current);
     return program_object_ && GLuint(current) == program_object_;
@@ -321,7 +321,7 @@ void GPUProgram::build() {
     link(); //Now link the program
 }
 
-const bool GPUProgram::is_complete() const {
+bool GPUProgram::is_complete() const {
     //Vertex and Fragment shader are required
     if(!program_object_ || !shaders_.count(SHADER_TYPE_VERTEX) || !shaders_.count(SHADER_TYPE_FRAGMENT)) {
         return false;
@@ -338,7 +338,7 @@ const bool GPUProgram::is_complete() const {
     return false;
 }
 
-const bool GPUProgram::is_compiled(ShaderType type) const {
+bool GPUProgram::is_compiled(ShaderType type) const {
     return shaders_.at(type).is_compiled;
 }
 

--- a/simulant/renderers/gl2x/gpu_program.h
+++ b/simulant/renderers/gl2x/gpu_program.h
@@ -76,11 +76,11 @@ public:
     bool init() override;
     void cleanup() override;
 
-    const bool is_current() const;
+    bool is_current() const;
     void activate();
 
-    const bool is_complete() const;
-    const bool is_compiled(ShaderType type) const;
+    bool is_complete() const;
+    bool is_compiled(ShaderType type) const;
 
     void compile(ShaderType type);
     void build();

--- a/simulant/stage.cpp
+++ b/simulant/stage.cpp
@@ -184,7 +184,7 @@ ActorPtr Stage::actor(ActorID e) {
     return ActorManager::get(e);
 }
 
-const ActorPtr Stage::actor(ActorID e) const {
+ActorPtr Stage::actor(ActorID e) const {
     return ActorManager::get(e);
 }
 

--- a/simulant/stage.h
+++ b/simulant/stage.h
@@ -118,7 +118,7 @@ public:
     ActorPtr new_actor_with_parent_and_mesh(ActorID parent, MeshID mid, RenderableCullingMode mode=RENDERABLE_CULLING_MODE_PARTITIONER);
     ActorPtr new_actor_with_parent_and_mesh(SpriteID parent, MeshID mid, RenderableCullingMode mode=RENDERABLE_CULLING_MODE_PARTITIONER);
     ActorPtr actor(ActorID e);
-    const ActorPtr actor(ActorID e) const;
+    ActorPtr actor(ActorID e) const;
     bool has_actor(ActorID e) const;
     ActorPtr delete_actor(ActorID e);
     std::size_t actor_count() const { return ActorManager::count(); }

--- a/simulant/types.cpp
+++ b/simulant/types.cpp
@@ -55,7 +55,7 @@ bool VertexSpecification::has_texcoordX(uint8_t which) const {
            (which == 7) ? has_texcoord7() : false;
 }
 
-const VertexAttribute VertexSpecification::texcoordX_attribute(uint8_t which) const {
+VertexAttribute VertexSpecification::texcoordX_attribute(uint8_t which) const {
     assert(which < MAX_TEXTURE_UNITS);
 
     switch(which) {

--- a/simulant/types.h
+++ b/simulant/types.h
@@ -253,7 +253,7 @@ public:
 
     bool has_texcoordX(uint8_t which) const;
 
-    const VertexAttribute texcoordX_attribute(uint8_t which) const;
+    VertexAttribute texcoordX_attribute(uint8_t which) const;
 
     bool has_texcoord0() const { return bool(texcoord0_attribute_); }
     bool has_texcoord1() const { return bool(texcoord1_attribute_); }

--- a/simulant/vertex_data.h
+++ b/simulant/vertex_data.h
@@ -137,8 +137,8 @@ public:
     sig::signal<void ()>& signal_update_complete() { return signal_update_complete_; }
     bool empty() const { return data_.empty(); }
 
-    const int32_t cursor_position() const { return cursor_position_; }
-    const int32_t cursor_offset() const { return cursor_position_ * stride_; }
+    int32_t cursor_position() const { return cursor_position_; }
+    int32_t cursor_offset() const { return cursor_position_ * stride_; }
 
     inline uint32_t stride() const {
         return stride_;

--- a/simulant/viewport.h
+++ b/simulant/viewport.h
@@ -50,10 +50,10 @@ public:
     Viewport(ViewportType type, const Colour& colour=smlt::Colour::BLACK);
     Viewport(Ratio x, Ratio y, Ratio width, Ratio height, const Colour& colour=smlt::Colour::BLACK);
 
-    const Ratio x() const { return x_; }
-    const Ratio y() const { return y_; }
-    const Ratio width() const { return width_; }
-    const Ratio height() const { return height_; }
+    Ratio x() const { return x_; }
+    Ratio y() const { return y_; }
+    Ratio width() const { return width_; }
+    Ratio height() const { return height_; }
 
     void clear(const RenderTarget& target, uint32_t clear_flags);
     void apply(const RenderTarget& target);

--- a/simulant/window.h
+++ b/simulant/window.h
@@ -143,7 +143,7 @@ public:
     void set_logging_level(LoggingLevel level);
 
     void stop_running() { is_running_ = false; }
-    const bool is_shutting_down() const { return is_running_ == false; }
+    bool is_shutting_down() const { return is_running_ == false; }
 
     void enable_virtual_joypad(VirtualGamepadConfig config, bool flipped=false);
     void disable_virtual_joypad();


### PR DESCRIPTION
- [x] I agree that the changes introduced in this PR are dual-licensed under the [LGPL-3.0](https://opensource.org/licenses/LGPL-3.0) and [MIT](https://opensource.org/licenses/mit-license) licenses ([Why?](https://github.com/Kazade/simulant-engine/blob/master/documentation/license.md))