### PR TITLE
Added extra debug flags to Dreamcast CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ IF(NOT PLATFORM_DREAMCAST)
 set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wextra")
 ELSE()
 # On the Dreamcast, force a frame pointer when debugging
-set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer")
+set (CMAKE_CXX_FLAGS_DEBUG "-g ${CMAKE_CXX_FLAGS_DEBUG} -DFRAME_POINTERS -fno-omit-frame-pointer -Og")
 ENDIF()
 
 IF(SIMULANT_ENABLE_ASAN)


### PR DESCRIPTION
# Summary of Changes Introduced
- I had issues without -g being first
- Og generates more debugger friendly code
...

# PR Checklist

- [X] I have documented any user-visible changes to the code in the documentation folder
- [X] I agree that the changes introduced in this PR are dual-licensed under the [LGPL-3.0](https://opensource.org/licenses/LGPL-3.0) and [MIT](https://opensource.org/licenses/mit-license) licenses ([Why?](https://github.com/Kazade/simulant-engine/blob/master/documentation/license.md))
- [X] I have added applicable tests, or at least not introduced any failures
